### PR TITLE
Handle key press of the input

### DIFF
--- a/packages/module/src/VirtualAssistant/VirtualAssistant.test.tsx
+++ b/packages/module/src/VirtualAssistant/VirtualAssistant.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom'
 import VirtualAssistant from './VirtualAssistant';
 
@@ -77,6 +78,70 @@ describe('VirtualAssistant', () => {
       isSendButtonDisabled={true}
     />);
     expect(screen.getByRole("button")).not.toBeEnabled();
+  });
+
+  it('should trigger onSendMessage when pressing enter if there is a message', async () => {
+    const user = userEvent.setup();
+    const listener = jest.fn();
+    render(<VirtualAssistant
+      onSendMessage={listener}
+      message="hello world"
+    />);
+
+    await user.type(screen.getByRole("textbox"), "[Enter]");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.lastCall[0]).toBe('hello world');
+  });
+
+  it('should not trigger onSendMessage when pressing shift+enter if there is a message', async () => {
+    const user = userEvent.setup();
+    const listener = jest.fn();
+    render(<VirtualAssistant
+      onSendMessage={listener}
+      message="hello world"
+    />);
+
+    await user.type(screen.getByRole("textbox"), "{Shift>}[Enter]{/Shift}");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger onSendMessage when pressing enter if there is no text', async () => {
+    const user = userEvent.setup();
+    const listener = jest.fn();
+    render(<VirtualAssistant
+      onSendMessage={listener}
+      message=""
+    />);
+
+    await user.type(screen.getByRole("textbox"), "[Enter]");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger onSendMessage when pressing enter if there is only spaces / new lines and other empty content', async () => {
+    const user = userEvent.setup();
+    const message = "  \n\n\n  \t\t   \n\n\t\t  ";
+    const listener = jest.fn();
+    render(<VirtualAssistant
+      onSendMessage={listener}
+      message={message}
+    />);
+
+    await user.type(screen.getByRole("textbox"), "[Enter]");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger onSendMessage when pressing enter if the send button is disabled', async () => {
+    const user = userEvent.setup();
+    const listener = jest.fn();
+    render(<VirtualAssistant
+      onSendMessage={listener}
+      isSendButtonDisabled
+      message="hello world"
+    />);
+
+    await user.type(screen.getByRole("textbox"), "[Enter]");
+    expect(listener).not.toHaveBeenCalled();
   });
 
 });

--- a/packages/module/src/VirtualAssistant/VirtualAssistant.tsx
+++ b/packages/module/src/VirtualAssistant/VirtualAssistant.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { KeyboardEventHandler } from 'react';
 import {
   Button,
   Card,
@@ -83,6 +83,18 @@ export const VirtualAssistant: React.FunctionComponent<VirtualAssistantProps> = 
 }: VirtualAssistantProps) => {
   const classes = useStyles();
 
+  const handleKeyPress: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
+    if (event.key === 'Enter' || event.keyCode === 13) {
+      if (!event.shiftKey) {
+        if (message.trim() === '' || isSendButtonDisabled) {
+          event.preventDefault();
+        } else {
+          onSendMessage && onSendMessage(message);
+        }
+      }
+    }
+  };
+
   return (
     <Card className={classes.card}>
       <CardHeader className={classes.cardHeader} actions={actions ? {
@@ -102,6 +114,7 @@ export const VirtualAssistant: React.FunctionComponent<VirtualAssistantProps> = 
             placeholder={inputPlaceholder}
             value={message}
             onChange={onChangeMessage}
+            onKeyPress={handleKeyPress}
             type="text"
             aria-label="Assistant input"
             isDisabled={isInputDisabled}


### PR DESCRIPTION
We were missing this functionality in the extension, basically being able to press Enter key to send a message.
I was thinking whether we should pass the keypress handler and do it from our virtual assistant or in the extension.
Since this is a similar functionality as other chat clients, it makes sense to have it here directly.

I didn't add any way to override, but if we feel that this is a need in the future we could accept the keypress handler.


  - Allow to send the messages when pressing enter key
  - Behaves like it does on chat clients, pressing shift + enter will jump to the next line instead of sending the message
  - Adding tests