### PR TITLE
feat(PreviewAttachment): add Preview Attachment component 

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/PreviewAttachment/PreviewAttachment.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/PreviewAttachment/PreviewAttachment.md
@@ -1,0 +1,22 @@
+---
+# Sidenav top-level section
+# should be the same for all markdown files
+section: extensions
+subsection: Chat bots / AI
+# Sidenav secondary level section
+# should be the same for all markdown files
+id: Preview attachment
+# Tab (react | react-demos | html | html-demos | design-guidelines | accessibility)
+source: react
+# If you use typescript, the name of the interface to display props for
+# These are found through the sourceProps function provided in patternfly-docs.source.js
+propComponents: ['PreviewAttachment']
+---
+
+import PreviewAttachment from '@patternfly/virtual-assistant/dist/dynamic/PreviewAttachment';
+
+### Basic example
+
+```js file="./PreviewAttachment.tsx"
+
+```

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/PreviewAttachment/PreviewAttachment.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/PreviewAttachment/PreviewAttachment.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core';
-import { AttachmentEdit } from '@patternfly/virtual-assistant/dist/dynamic/AttachmentEdit';
+import { PreviewAttachment } from '@patternfly/virtual-assistant/dist/dynamic/PreviewAttachment';
 
 export const BasicDemo: React.FunctionComponent = () => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
@@ -12,14 +12,13 @@ export const BasicDemo: React.FunctionComponent = () => {
   return (
     <>
       <Button onClick={handleModalToggle}>Launch modal</Button>
-      <AttachmentEdit
+      <PreviewAttachment
         code="I am a code snippet"
         fileName="test.yaml"
         handleModalToggle={handleModalToggle}
         isModalOpen={isModalOpen}
-        onCancel={() => null}
-        // eslint-disable-next-line no-console
-        onSave={(_event, code) => console.log(`The new code is "${code}"`)}
+        onDismiss={() => null}
+        onEdit={() => null}
       />
     </>
   );

--- a/packages/module/src/AttachmentEdit/AttachmentEdit.tsx
+++ b/packages/module/src/AttachmentEdit/AttachmentEdit.tsx
@@ -2,22 +2,7 @@
 // Attachment Edit - Chatbot Code Snippet Editor
 // ============================================================================
 import React from 'react';
-import path from 'path';
-
-// Import PatternFly components
-import { CodeEditor, Language } from '@patternfly/react-code-editor';
-import {
-  Button,
-  Flex,
-  Icon,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  Stack,
-  StackItem
-} from '@patternfly/react-core';
-import { CodeIcon } from '@patternfly/react-icons';
+import CodeModal from '../CodeModal';
 
 export interface AttachmentEditProps {
   /** Text shown in code editor */
@@ -26,8 +11,8 @@ export interface AttachmentEditProps {
   fileName: string;
   /** Function that runs when cancel button is clicked  */
   onCancel: (event: React.MouseEvent | MouseEvent | KeyboardEvent) => void;
-  /** Function that runs when save button is clicked  */
-  onSave: (event: React.MouseEvent | MouseEvent | KeyboardEvent) => void;
+  /** Function that runs when save button is clicked; allows consumers to use the edited code string  */
+  onSave: (event: React.MouseEvent | MouseEvent | KeyboardEvent, code: string) => void;
   /** Function that opens and closes modal */
   handleModalToggle: (event: React.MouseEvent | MouseEvent | KeyboardEvent) => void;
   /** Whether modal is open */
@@ -43,12 +28,11 @@ export const AttachmentEdit: React.FunctionComponent<AttachmentEditProps> = ({
   isModalOpen,
   onCancel,
   onSave,
-  title = 'Edit attachment',
-  ...props
+  title = 'Edit attachment'
 }: AttachmentEditProps) => {
-  const handleSave = (_event: React.MouseEvent | MouseEvent | KeyboardEvent) => {
+  const handleSave = (_event: React.MouseEvent | MouseEvent | KeyboardEvent, code) => {
     handleModalToggle(_event);
-    onSave(_event);
+    onSave(_event, code);
   };
 
   const handleCancel = (_event: React.MouseEvent | MouseEvent | KeyboardEvent) => {
@@ -56,67 +40,18 @@ export const AttachmentEdit: React.FunctionComponent<AttachmentEditProps> = ({
     onCancel(_event);
   };
 
-  const onEditorDidMount = (editor, monaco) => {
-    editor.layout();
-    editor.focus();
-    monaco.editor.getModels()[0].updateOptions({ tabSize: 5 });
-  };
-
   return (
-    <Modal
-      isOpen={isModalOpen}
-      onClose={handleModalToggle}
-      ouiaId="EditAttachmentModal"
-      aria-labelledby="edit-attachment-title"
-      aria-describedby="edit-attachment-modal"
-      width="25%"
-    >
-      <ModalHeader title={title} labelId="edit-attachment-title" />
-      <ModalBody id="edit-attachment-body">
-        <Stack hasGutter>
-          <StackItem>
-            <Flex>
-              <Flex
-                className="pf-chatbot__attachment-icon"
-                justifyContent={{ default: 'justifyContentCenter' }}
-                alignItems={{ default: 'alignItemsCenter' }}
-                alignSelf={{ default: 'alignSelfCenter' }}
-              >
-                <Icon>
-                  <CodeIcon color="white" />
-                </Icon>
-              </Flex>
-              <Stack>
-                <StackItem>{path.parse(fileName).name}</StackItem>
-                <StackItem className="pf-chatbot__attachment-language">
-                  {Language[path.extname(fileName).slice(1)].toUpperCase()}
-                </StackItem>
-              </Stack>
-            </Flex>
-          </StackItem>
-          <StackItem>
-            <CodeEditor
-              isDarkTheme
-              isLineNumbersVisible
-              isLanguageLabelVisible
-              code={code}
-              language={Language[path.extname(fileName).slice(1)]}
-              onEditorDidMount={onEditorDidMount}
-              height="400px"
-              {...props}
-            />
-          </StackItem>
-        </Stack>
-      </ModalBody>
-      <ModalFooter>
-        <Button isBlock key="confirm" variant="primary" onClick={handleSave}>
-          Save
-        </Button>
-        <Button isBlock key="cancel" variant="secondary" onClick={handleCancel}>
-          Cancel
-        </Button>
-      </ModalFooter>
-    </Modal>
+    <CodeModal
+      code={code}
+      fileName={fileName}
+      handleModalToggle={handleModalToggle}
+      isModalOpen={isModalOpen}
+      onPrimaryAction={handleSave}
+      onSecondaryAction={handleCancel}
+      primaryActionBtn="Save"
+      secondaryActionBtn="Cancel"
+      title={title}
+    />
   );
 };
 

--- a/packages/module/src/CodeModal/CodeModal.scss
+++ b/packages/module/src/CodeModal/CodeModal.scss
@@ -1,9 +1,9 @@
-.pf-chatbot__attachment-language {
+.pf-chatbot__code-language {
   color: var(--pf-t--global--text--color--subtle);
   font-size: var(--pf-t--global--icon--size--font--xs);
 }
 
-.pf-chatbot__attachment-icon {
+.pf-chatbot__code-icon {
   background-color: var(--pf-t--global--icon--color--status--custom--default);
   border-radius: var(--pf-t--global--border--radius--tiny);
   width: 24px;

--- a/packages/module/src/CodeModal/CodeModal.tsx
+++ b/packages/module/src/CodeModal/CodeModal.tsx
@@ -1,0 +1,150 @@
+// ============================================================================
+// Code Modal - Chatbot Modal with Code Editor
+// ============================================================================
+import React, { useState } from 'react';
+import path from 'path';
+
+// Import PatternFly components
+import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import {
+  Button,
+  Flex,
+  Icon,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Stack,
+  StackItem
+} from '@patternfly/react-core';
+import { CodeIcon } from '@patternfly/react-icons';
+
+export interface CodeModalProps {
+  /** Text shown in code editor */
+  code: string;
+  /** Filename, including extension, of file shown in editor */
+  fileName: string;
+  /** Whether copying code is allowed */
+  isCopyEnabled?: boolean;
+  /** Whether code is read-only */
+  isReadOnly?: boolean;
+  /** Action assigned to primary modal button */
+  onPrimaryAction: (event: React.MouseEvent | MouseEvent | KeyboardEvent, code?: string) => void;
+  /** Action assigned to secondary modal button */
+  onSecondaryAction: (event: React.MouseEvent | MouseEvent | KeyboardEvent) => void;
+  /** Name of primary modal button */
+  primaryActionBtn: string;
+  /** Name of secondary modal button */
+  secondaryActionBtn: string;
+  /** Function that handles modal toggle */
+  handleModalToggle: (event: React.MouseEvent | MouseEvent | KeyboardEvent) => void;
+  /** Whether modal is open */
+  isModalOpen: boolean;
+  /** Title of modal */
+  title: string;
+}
+
+export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
+  fileName,
+  code,
+  handleModalToggle,
+  isCopyEnabled,
+  isModalOpen,
+  isReadOnly,
+  onPrimaryAction,
+  onSecondaryAction,
+  primaryActionBtn,
+  secondaryActionBtn,
+  title,
+  ...props
+}: CodeModalProps) => {
+  const [newCode, setNewCode] = useState(code);
+
+  const handlePrimaryAction = (_event: React.MouseEvent | MouseEvent | KeyboardEvent) => {
+    handleModalToggle(_event);
+    if (!isReadOnly) {
+      onPrimaryAction(_event, newCode);
+    } else {
+      onPrimaryAction(_event);
+    }
+  };
+
+  const handleSecondaryAction = (_event: React.MouseEvent | MouseEvent | KeyboardEvent) => {
+    handleModalToggle(_event);
+    onSecondaryAction(_event);
+  };
+
+  const onEditorDidMount = (editor, monaco) => {
+    editor.layout();
+    editor.focus();
+    monaco.editor.getModels()[0].updateOptions({ tabSize: 5 });
+  };
+
+  const onCodeChange = (value: string) => {
+    if (!isReadOnly) {
+      setNewCode(value);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isModalOpen}
+      onClose={handleModalToggle}
+      ouiaId="CodeModal"
+      aria-labelledby="code-modal-title"
+      aria-describedby="code-modal"
+      width="25%"
+    >
+      <ModalHeader title={title} labelId="code-modal-title" />
+      <ModalBody id="code-modal-body">
+        <Stack hasGutter>
+          <StackItem>
+            <Flex>
+              <Flex
+                className="pf-chatbot__code-icon"
+                justifyContent={{ default: 'justifyContentCenter' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+                alignSelf={{ default: 'alignSelfCenter' }}
+              >
+                <Icon>
+                  <CodeIcon color="white" />
+                </Icon>
+              </Flex>
+              <Stack>
+                <StackItem>{path.parse(fileName).name}</StackItem>
+                <StackItem className="pf-chatbot__code-language">
+                  {Language[path.extname(fileName).slice(1)].toUpperCase()}
+                </StackItem>
+              </Stack>
+            </Flex>
+          </StackItem>
+          <StackItem>
+            <CodeEditor
+              isDarkTheme
+              isLineNumbersVisible
+              isLanguageLabelVisible
+              isCopyEnabled={isCopyEnabled}
+              isReadOnly={isReadOnly}
+              code={newCode}
+              language={Language[path.extname(fileName).slice(1)]}
+              onEditorDidMount={onEditorDidMount}
+              height="400px"
+              onCodeChange={onCodeChange}
+              {...props}
+            />
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
+        <Button isBlock key="code-modal-primary" variant="primary" onClick={handlePrimaryAction} form="code-modal-form">
+          {primaryActionBtn}
+        </Button>
+        <Button isBlock key="code-modal-secondary" variant="secondary" onClick={handleSecondaryAction}>
+          {secondaryActionBtn}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default CodeModal;

--- a/packages/module/src/CodeModal/index.ts
+++ b/packages/module/src/CodeModal/index.ts
@@ -1,0 +1,3 @@
+export { default } from './CodeModal';
+
+export * from './CodeModal';

--- a/packages/module/src/PreviewAttachment/PreviewAttachment.tsx
+++ b/packages/module/src/PreviewAttachment/PreviewAttachment.tsx
@@ -1,0 +1,60 @@
+// ============================================================================
+// Preview Attachment - Chatbot Code Snippet Viewer
+// ============================================================================
+import React from 'react';
+import CodeModal from '../CodeModal';
+
+export interface PreviewAttachmentProps {
+  /** Text shown in code editor */
+  code: string;
+  /** Filename, including extension, of file shown in modal */
+  fileName: string;
+  /** Function called when edit button is clicked */
+  onEdit: (event: React.MouseEvent | MouseEvent | KeyboardEvent) => void;
+  /** Function called when dismiss button is clicked */
+  onDismiss?: (event: React.MouseEvent | MouseEvent | KeyboardEvent) => void;
+  /** Function called when modal is toggled */
+  handleModalToggle: (event: React.MouseEvent | MouseEvent | KeyboardEvent) => void;
+  /** Whether modal is open */
+  isModalOpen: boolean;
+  /** Title of modal */
+  title?: string;
+}
+
+export const PreviewAttachment: React.FunctionComponent<PreviewAttachmentProps> = ({
+  fileName,
+  code,
+  handleModalToggle,
+  isModalOpen,
+  onDismiss = undefined,
+  onEdit,
+  title = 'Preview attachment'
+}: PreviewAttachmentProps) => {
+  const handleEdit = (_event: React.MouseEvent | MouseEvent | KeyboardEvent) => {
+    handleModalToggle(_event);
+    onEdit(_event);
+  };
+
+  const handleDismiss = (_event: React.MouseEvent | MouseEvent | KeyboardEvent) => {
+    handleModalToggle(_event);
+    onDismiss && onDismiss(_event);
+  };
+
+  return (
+    <CodeModal
+      code={code}
+      fileName={fileName}
+      handleModalToggle={handleModalToggle}
+      isCopyEnabled
+      isModalOpen={isModalOpen}
+      onPrimaryAction={handleEdit}
+      onSecondaryAction={handleDismiss}
+      primaryActionBtn="Edit"
+      secondaryActionBtn="Dismiss"
+      title={title}
+      isReadOnly
+    />
+  );
+};
+
+export default PreviewAttachment;

--- a/packages/module/src/PreviewAttachment/index.ts
+++ b/packages/module/src/PreviewAttachment/index.ts
@@ -1,0 +1,3 @@
+export { default } from './PreviewAttachment';
+
+export * from './PreviewAttachment';

--- a/packages/module/src/index.ts
+++ b/packages/module/src/index.ts
@@ -12,6 +12,9 @@ export * from './ChatbotHeader';
 export { default as ChatbotToggle } from './ChatbotToggle';
 export * from './ChatbotToggle';
 
+export { default as CodeModal } from './CodeModal';
+export * from './CodeModal';
+
 export { default as ConversationAlert } from './ConversationAlert';
 export * from './ConversationAlert';
 
@@ -26,6 +29,9 @@ export * from './MessageBar';
 
 export { default as Popover } from './Popover';
 export * from './Popover';
+
+export { default as PreviewAttachment } from './PreviewAttachment';
+export * from './PreviewAttachment';
 
 export { default as SystemMessageEntry } from './SystemMessageEntry';
 export * from './SystemMessageEntry';

--- a/packages/module/src/main.scss
+++ b/packages/module/src/main.scss
@@ -1,7 +1,7 @@
-@import './AttachmentEdit/AttachmentEdit';
 @import './ChatbotConversationHistoryNav/ChatbotConversationHistoryNav';
 @import './ChatbotHeader/ChatbotHeader.scss';
 @import './ChatbotToggle/ChatbotToggle';
+@import './CodeModal/CodeModal';
 @import './Footer/Footer';
 @import './Footer/Footnote';
 @import './MessageBar/AttachButton';


### PR DESCRIPTION
Will be easier to review after https://github.com/patternfly/virtual-assistant/pull/82 merges since it modifies the commit there.

Turned EditAttachment into a reusable CodeModal component so I could use the same base component for both EditAttachment and PreviewAttachment. Added limited customization required for PreviewAttachment. The same disclaimers apply for PreviewAttachment for the design - I am using the standard code editor and modal with no adjustments since we have a need for speed. We'll go back and modify as needed once designs are final.

Fixes https://github.com/patternfly/virtual-assistant/issues/58.