### PR TITLE
feat(FileDropZone): Add drop zone for file upload purposes

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/FileDropZone/FileDropZone.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/FileDropZone/FileDropZone.md
@@ -1,0 +1,22 @@
+---
+# Sidenav top-level section
+# should be the same for all markdown files
+section: extensions
+subsection: Chat bots / AI
+# Sidenav secondary level section
+# should be the same for all markdown files
+id: File drop zone
+# Tab (react | react-demos | html | html-demos | design-guidelines | accessibility)
+source: react
+# If you use typescript, the name of the interface to display props for
+# These are found through the sourceProps function provided in patternfly-docs.source.js
+propComponents: ['FileDropZone']
+---
+
+import FileDropZone from '@patternfly/virtual-assistant/dist/dynamic/FileDropZone';
+
+### Basic example
+
+```js file="./FileDropZone.tsx"
+
+```

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/FileDropZone/FileDropZone.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/FileDropZone/FileDropZone.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import FileDropZone from '@patternfly/virtual-assistant/dist/dynamic/FileDropZone';
+import { DropEvent } from '@patternfly/react-core';
+
+interface readFile {
+  fileName: string;
+  data?: string;
+  loadResult?: 'danger' | 'success';
+  loadError?: DOMException;
+}
+
+export const BasicDemo: React.FunctionComponent = () => {
+  const [currentFiles, setCurrentFiles] = React.useState<File[]>([]);
+  const [readFileData, setReadFileData] = React.useState<readFile[]>([]);
+
+  // remove files from both state arrays based on their name
+  const removeFiles = (namesOfFilesToRemove: string[]) => {
+    const newCurrentFiles = currentFiles.filter(
+      (currentFile) => !namesOfFilesToRemove.some((fileName) => fileName === currentFile.name)
+    );
+
+    setCurrentFiles(newCurrentFiles);
+
+    const newReadFiles = readFileData.filter(
+      (readFile) => !namesOfFilesToRemove.some((fileName) => fileName === readFile.fileName)
+    );
+
+    setReadFileData(newReadFiles);
+  };
+
+  // callback that will be called by the react dropzone with the newly dropped file objects
+  const handleFileDrop = (_event: DropEvent, droppedFiles: File[]) => {
+    // identify what, if any, files are re-uploads of already uploaded files
+    const currentFileNames = currentFiles.map((file) => file.name);
+    const reUploads = droppedFiles.filter((droppedFile) => currentFileNames.includes(droppedFile.name));
+
+    /** this promise chain is needed because if the file removal is done at the same time as the file adding react
+     * won't realize that the status items for the re-uploaded files needs to be re-rendered */
+    Promise.resolve()
+      .then(() => removeFiles(reUploads.map((file) => file.name)))
+      .then(() => alert(`Dropped ${droppedFiles.map((file) => file.name)}`));
+  };
+
+  return (
+    <FileDropZone onFileDrop={handleFileDrop}>
+      <div style={{ border: '1px solid black', width: '100%', padding: '1rem' }}>
+        Content that shows when no dragging is happening (drag an item here to see the drop zone)
+      </div>
+    </FileDropZone>
+  );
+};

--- a/packages/module/src/FileDropZone/FileDropZone.tsx
+++ b/packages/module/src/FileDropZone/FileDropZone.tsx
@@ -1,0 +1,56 @@
+import { DropEvent, MultipleFileUpload, MultipleFileUploadMain } from '@patternfly/react-core';
+import { UploadIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+export interface FileDropZoneProps {
+  /** Content displayed when the drop zone is not currently in use */
+  children?: React.ReactNode;
+  /** Custom classname for the outer dropzone component */
+  className?: string;
+  /** Informational text that shows below the title in the drop zone */
+  infoText?: string;
+  /** Maximum file size in bytes */
+  maxSize?: number;
+  /** When files are dropped or uploaded this callback will be called with all accepted files */
+  onFileDrop?: (event: DropEvent, data: File[]) => void;
+}
+
+const FileDropZone: React.FunctionComponent<FileDropZoneProps> = ({
+  children,
+  className,
+  infoText = 'Maximum file size is 25 MB',
+  maxSize = 25000000,
+  onFileDrop
+}: FileDropZoneProps) => {
+  const [showDropZone, setShowDropZone] = React.useState(false);
+
+  const renderDropZone = () => (
+    <>
+      <MultipleFileUploadMain
+        titleIcon={<UploadIcon />}
+        titleText="Drag and drop your file here"
+        infoText={infoText}
+        isUploadButtonHidden
+      />
+    </>
+  );
+
+  return (
+    <MultipleFileUpload
+      dropzoneProps={{
+        maxSize,
+        maxFiles: 1,
+        multiple: false,
+        onDrop: () => setShowDropZone(false)
+      }}
+      onDragEnter={() => setShowDropZone(true)}
+      onDragLeave={() => setShowDropZone(false)}
+      onFileDrop={onFileDrop}
+      className={className}
+    >
+      {showDropZone ? renderDropZone() : children}
+    </MultipleFileUpload>
+  );
+};
+
+export default FileDropZone;

--- a/packages/module/src/FileDropZone/index.ts
+++ b/packages/module/src/FileDropZone/index.ts
@@ -1,0 +1,3 @@
+export { default } from './FileDropZone';
+
+export * from './FileDropZone';

--- a/packages/module/src/index.ts
+++ b/packages/module/src/index.ts
@@ -30,6 +30,9 @@ export * from './CodeModal';
 export { default as ConversationAlert } from './ConversationAlert';
 export * from './ConversationAlert';
 
+export { default as FileDropZone } from './FileDropZone';
+export * from './FileDropZone';
+
 export { default as LoadingMessage } from './LoadingMessage';
 export * from './LoadingMessage';
 


### PR DESCRIPTION
Again, this deviates from the design significantly because the design isn't based on PatternFly 6. We are using PatternFly components where available for speedy development purposes. The only real big change here from the PatternFly demo is that the drop zone is hidden until engaged, and that we're not showing the status indicators. The design did not seem to include any handling here explicitly beyond what a successful upload looks like (outside of the scope of this component). We probably need a way to indicate a failure in a similar location.

Fixes https://github.com/patternfly/virtual-assistant/issues/59.