### PR TITLE
chore(AttachmentError): Add demo for AttachmentError

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/AttachmentError/AttachmentError.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/AttachmentError/AttachmentError.md
@@ -1,0 +1,17 @@
+---
+# Sidenav top-level section
+# should be the same for all markdown files
+section: extensions
+subsection: Chat bots / AI
+# Sidenav secondary level section
+# should be the same for all markdown files
+id: Attachment error
+# Tab (react | react-demos | html | html-demos | design-guidelines | accessibility)
+source: react
+---
+
+### Basic example
+
+```js file="./AttachmentError.tsx"
+
+```

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/AttachmentError/AttachmentError.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/AttachmentError/AttachmentError.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
+
+export const BasicDemo: React.FunctionComponent = () => (
+  <Alert
+    variant="danger"
+    // eslint-disable-next-line no-console
+    actionClose={<AlertActionCloseButton onClose={() => console.log('Clicked the close button')} />}
+    title="File upload failed"
+  >
+    Your file size is too large. Please ensure that your file is less than 25 MB.
+  </Alert>
+);


### PR DESCRIPTION
We can just use the default alert for this, hurray! But here is a sample of how to use it, that you can copy and paste.

Fixes https://github.com/patternfly/virtual-assistant/issues/90.