### PR TITLE
feat(ChatbotAttachment): Hook up attach button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "react-dropzone": "^14.2.3"
+      },
       "devDependencies": {
         "@babel/core": "^7.24.0",
         "@babel/plugin-proposal-private-property-in-object": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@octokit/rest": "^18.0.0",
-    "@patternfly/react-icons": "6.0.0-alpha.35",
-    "@patternfly/patternfly": "6.0.0-alpha.205",
     "@patternfly/documentation-framework": "6.0.0-alpha.79",
+    "@patternfly/patternfly": "6.0.0-alpha.205",
+    "@patternfly/react-icons": "6.0.0-alpha.35",
+    "@swc/core": "1.3.96",
     "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
@@ -54,10 +55,6 @@
     "chokidar": "^3.6.0",
     "concurrently": "^8.2.2",
     "cypress": "^13.7.1",
-    "@swc/core": "1.3.96",
-    "swc-loader": "0.2.3",
-    "sass": "^1.72.0",
-    "sass-loader": "^14.1.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-config-standard-with-typescript": "^23.0.0",
@@ -78,11 +75,17 @@
     "react": "^18",
     "react-dom": "^18",
     "rimraf": "^5.0.5",
+    "sass": "^1.72.0",
+    "sass-loader": "^14.1.1",
     "serve": "^14.2.1",
     "start-server-and-test": "^2.0.3",
     "surge": "^0.23.1",
+    "swc-loader": "0.2.3",
     "ts-jest": "29.1.2",
     "wait-on": "^7.2.0",
     "whatwg-fetch": "^3.6.20"
+  },
+  "dependencies": {
+    "react-dropzone": "^14.2.3"
   }
 }

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotAttachment/ChatbotAttachment.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotAttachment/ChatbotAttachment.tsx
@@ -98,29 +98,49 @@ export const BasicDemo: React.FunctionComponent = () => {
 
   // Attachments
   // --------------------------------------------------------------------------
-  const handleFile = (data: File[]) => {
+  // example of how you can read a text file
+  const readFile = (file: File) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(file);
+      // you can use reader.readAsText(file) for human-readable file types;
+    });
+
+  // handle file drop/selection
+  const handleFile = (fileArr: File[]) => {
+    setIsLoadingFile(true);
     // any custom validation you may want
-    if (data.length > 1) {
+    if (fileArr.length > 1) {
       setShowAlert(true);
       setFile(undefined);
       setError('Uploaded more than one file.');
       return;
     }
     // this is 25MB in bytes; size is in bytes
-    if (data[0].size > 25000000) {
+    if (fileArr[0].size > 25000000) {
       setShowAlert(true);
       setFile(undefined);
       setError('File is larger than 25MB.');
       return;
     }
 
-    setFile(data[0]);
-    setIsLoadingFile(true);
-    setShowAlert(false);
-    setError(undefined);
-    setTimeout(() => {
-      setIsLoadingFile(false);
-    }, 1000);
+    readFile(fileArr[0])
+      .then((data) => {
+        // eslint-disable-next-line no-console
+        console.log(data);
+        setFile(fileArr[0]);
+        setShowAlert(false);
+        setError(undefined);
+        // this is just for demo purposes, to make the loading state really obvious
+        setTimeout(() => {
+          setIsLoadingFile(false);
+        }, 1000);
+      })
+      .catch((error: DOMException) => {
+        setError(`Failed to read file: ${error.message}`);
+      });
   };
 
   const handleFileDrop = (event: DropEvent, data: File[]) => {

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotAttachment/ChatbotAttachment.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotAttachment/ChatbotAttachment.tsx
@@ -96,16 +96,20 @@ export const BasicDemo: React.FunctionComponent = () => {
   const [showAlert, setShowAlert] = React.useState<boolean>(false);
   const handleSend = (message) => alert(message);
 
-  const handleFileDrop = (event: DropEvent, data: File[]) => {
+  // Attachments
+  // --------------------------------------------------------------------------
+  const handleFile = (data: File[]) => {
     // any custom validation you may want
     if (data.length > 1) {
       setShowAlert(true);
+      setFile(undefined);
       setError('Uploaded more than one file.');
       return;
     }
     // this is 25MB in bytes; size is in bytes
     if (data[0].size > 25000000) {
       setShowAlert(true);
+      setFile(undefined);
       setError('File is larger than 25MB.');
       return;
     }
@@ -119,11 +123,12 @@ export const BasicDemo: React.FunctionComponent = () => {
     }, 1000);
   };
 
-  // Attachments
-  // --------------------------------------------------------------------------
-  const handleAttach = () => {
-    // eslint-disable-next-line no-console
-    console.log('Attach button clicked');
+  const handleFileDrop = (event: DropEvent, data: File[]) => {
+    handleFile(data);
+  };
+
+  const handleAttach = (data: File[]) => {
+    handleFile(data);
   };
 
   const onClose = () => {

--- a/packages/module/src/MessageBar/AttachButton.tsx
+++ b/packages/module/src/MessageBar/AttachButton.tsx
@@ -4,13 +4,15 @@
 import React from 'react';
 
 // Import PatternFly components
-import { Button, ButtonProps, Tooltip, TooltipProps, Icon } from '@patternfly/react-core';
-
+import { Button, ButtonProps, DropEvent, Icon, Tooltip, TooltipProps } from '@patternfly/react-core';
+import { useDropzone } from 'react-dropzone';
 import { PaperclipIcon } from '@patternfly/react-icons/dist/esm/icons/paperclip-icon';
 
 export interface AttachButtonProps extends ButtonProps {
   /** OnClick Handler for the Attach Button */
   onClick?: ((event: MouseEvent | React.MouseEvent<Element, MouseEvent> | KeyboardEvent) => void) | undefined;
+  /** Callback function for attach button when an attachment is made */
+  onAttachAccepted?: (data: File[], event: DropEvent) => void;
   /** Class Name for the Attach button */
   className?: string;
   /** Props to control is the attach button should be disabled */
@@ -22,40 +24,47 @@ export interface AttachButtonProps extends ButtonProps {
 }
 
 const AttachButtonBase: React.FunctionComponent<AttachButtonProps> = ({
+  onAttachAccepted,
   onClick,
   isDisabled,
   className,
   tooltipProps,
   innerRef,
   ...props
-}: AttachButtonProps) => (
-  <Tooltip
-    id="pf-chatbot__tooltip--attach"
-    content="Attach"
-    position="top"
-    entryDelay={tooltipProps?.entryDelay || 0}
-    exitDelay={tooltipProps?.exitDelay || 0}
-    distance={tooltipProps?.distance || 8}
-    animationDuration={tooltipProps?.animationDuration || 0}
-    {...tooltipProps}
-  >
-    <Button
-      variant="plain"
-      ref={innerRef}
-      className={`pf-chatbot__button--attach ${className ?? ''}`}
-      aria-describedby="pf-chatbot__tooltip--attach"
-      aria-label={props['aria-label'] || 'Attach Button'}
-      isDisabled={isDisabled}
-      onClick={onClick}
-      icon={
-        <Icon iconSize="xl" isInline>
-          <PaperclipIcon />
-        </Icon>
-      }
-      {...props}
-    />
-  </Tooltip>
-);
+}: AttachButtonProps) => {
+  const { open } = useDropzone({
+    multiple: true,
+    onDropAccepted: onAttachAccepted
+  });
+  return (
+    <Tooltip
+      id="pf-chatbot__tooltip--attach"
+      content="Attach"
+      position="top"
+      entryDelay={tooltipProps?.entryDelay || 0}
+      exitDelay={tooltipProps?.exitDelay || 0}
+      distance={tooltipProps?.distance || 8}
+      animationDuration={tooltipProps?.animationDuration || 0}
+      {...tooltipProps}
+    >
+      <Button
+        variant="plain"
+        ref={innerRef}
+        className={`pf-chatbot__button--attach ${className ?? ''}`}
+        aria-describedby="pf-chatbot__tooltip--attach"
+        aria-label={props['aria-label'] || 'Attach Button'}
+        isDisabled={isDisabled}
+        onClick={onClick ?? open}
+        icon={
+          <Icon iconSize="xl" isInline>
+            <PaperclipIcon />
+          </Icon>
+        }
+        {...props}
+      />
+    </Tooltip>
+  );
+};
 
 export const AttachButton = React.forwardRef((props: AttachButtonProps, ref: React.Ref<any>) => (
   <AttachButtonBase innerRef={ref} {...props} />

--- a/packages/module/src/MessageBar/MessageBar.scss
+++ b/packages/module/src/MessageBar/MessageBar.scss
@@ -52,6 +52,16 @@
     line-height: 24px;
   }
 
+  .pf-chatbot__message-bar-input {
+    flex: 1 0 0;
+  }
+
+  .pf-chatbot__message-bar-actions {
+    align-items: center;
+    height: 100%;
+    display: flex;
+  }
+
   //.pf-chatbot__message-textarea {
   //  --pf-v6-c-form-control--Resize: none;
   //  --pf-v6-c-form-control--before--BorderStyle: none;

--- a/packages/module/src/MessageBar/MessageBar.tsx
+++ b/packages/module/src/MessageBar/MessageBar.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Flex, FlexItem, TextAreaProps } from '@patternfly/react-core';
+import { DropEvent, Flex, FlexItem, TextAreaProps } from '@patternfly/react-core';
+import { AutoTextArea } from 'react-textarea-auto-witdth-height';
+
+// Import Chatbot components
 import SendButton from './SendButton';
 import MicrophoneButton from './MicrophoneButton';
 import { AttachButton } from './AttachButton';
-import { AutoTextArea } from 'react-textarea-auto-witdth-height';
 import AttachMenu from '../AttachMenu';
 
 export interface MessageBarWithAttachMenuProps {
@@ -38,8 +40,8 @@ export interface MessageBarProps extends TextAreaProps {
   hasAttachButton?: boolean;
   /** Flag to enable the Microphone button  */
   hasMicrophoneButton?: boolean;
-  /** Callback function for when attach button is clicked */
-  handleAttach?: (event: React.MouseEvent | MouseEvent | KeyboardEvent) => void;
+  /** Callback function for when attach button is used to upload a file */
+  handleAttach?: (data: File[], event: DropEvent) => void;
   /** Props to enable a menu that opens when the Attach button is clicked, instead of the attachment window */
   attachMenuProps?: MessageBarWithAttachMenuProps;
 }
@@ -157,7 +159,9 @@ export const MessageBar: React.FC<MessageBarProps & MessageBarWithAttachMenuProp
       </FlexItem>
 
       <FlexItem className="pf-chatbot__message-bar-actions">
-        {hasAttachButton && <AttachButton onClick={handleAttach} isDisabled={isListeningMessage} />}
+        {hasAttachButton && handleAttach && (
+          <AttachButton onAttachAccepted={handleAttach} isDisabled={isListeningMessage} />
+        )}
         {hasMicrophoneButton && (
           <MicrophoneButton
             isListening={isListeningMessage}

--- a/packages/module/src/MessageBar/MessageBar.tsx
+++ b/packages/module/src/MessageBar/MessageBar.tsx
@@ -159,9 +159,7 @@ export const MessageBar: React.FC<MessageBarProps & MessageBarWithAttachMenuProp
       </FlexItem>
 
       <FlexItem className="pf-chatbot__message-bar-actions">
-        {hasAttachButton && handleAttach && (
-          <AttachButton onAttachAccepted={handleAttach} isDisabled={isListeningMessage} />
-        )}
+        {hasAttachButton && <AttachButton onAttachAccepted={handleAttach} isDisabled={isListeningMessage} />}
         {hasMicrophoneButton && (
           <MicrophoneButton
             isListening={isListeningMessage}


### PR DESCRIPTION
Used react-dropzone to hook up the attach button, and flowed it into the attachment demo.

Needs to merge after https://github.com/patternfly/virtual-assistant/pull/98 since it's based on that.

Fixes https://github.com/patternfly/virtual-assistant/issues/100.