### PR TITLE
fix(FileDropZone/CodeModal): Pass Chatbot display mode down

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/AttachmentDemos.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/AttachmentDemos.md
@@ -12,7 +12,7 @@ sourceLink: https://github.com/patternfly/virtual-assistant/blob/main/packages/m
 ---
 
 import ChatbotToggle from '@patternfly/virtual-assistant/dist/dynamic/ChatbotToggle';
-import Chatbot from '@patternfly/virtual-assistant/dist/dynamic/Chatbot';
+import Chatbot, { ChatbotDisplayMode } from '@patternfly/virtual-assistant/dist/dynamic/Chatbot';
 import ChatbotContent from '@patternfly/virtual-assistant/dist/dynamic/ChatbotContent';
 import ChatbotWelcomePrompt from '@patternfly/virtual-assistant/dist/dynamic/ChatbotWelcomePrompt';
 import ChatbotFooter, { ChatbotFootnote } from '@patternfly/virtual-assistant/dist/dynamic/ChatbotFooter';
@@ -26,6 +26,18 @@ import AttachmentEdit from '@patternfly/virtual-assistant/dist/dynamic/Attachmen
 import SourceDetailsMenuItem from '@patternfly/virtual-assistant/dist/dynamic/SourceDetailsMenuItem';
 import { BellIcon, CalendarAltIcon, ClipboardIcon, CodeIcon, UploadIcon } from '@patternfly/react-icons';
 import { useDropzone } from 'react-dropzone';
+import PFHorizontalLogoColor from '../ChatbotHeader/PF-HorizontalLogo-Color.svg';
+import PFHorizontalLogoReverse from '../ChatbotHeader/PF-HorizontalLogo-Reverse.svg';
+import ChatbotHeader, {
+ChatbotHeaderMenu,
+ChatbotHeaderTitle,
+ChatbotHeaderActions,
+ChatbotHeaderSelectorDropdown,
+ChatbotHeaderOptionsDropdown
+} from '@patternfly/virtual-assistant/dist/dynamic/ChatbotHeader';
+import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
+import OpenDrawerRightIcon from '@patternfly/react-icons/dist/esm/icons/open-drawer-right-icon';
+import OutlinedWindowRestoreIcon from '@patternfly/react-icons/dist/esm/icons/outlined-window-restore-icon';
 
 # Demos
 

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachment.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachment.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ChatbotToggle from '@patternfly/virtual-assistant/dist/dynamic/ChatbotToggle';
-import Chatbot from '@patternfly/virtual-assistant/dist/dynamic/Chatbot';
+import Chatbot, { ChatbotDisplayMode } from '@patternfly/virtual-assistant/dist/dynamic/Chatbot';
 import ChatbotContent from '@patternfly/virtual-assistant/dist/dynamic/ChatbotContent';
 import ChatbotWelcomePrompt from '@patternfly/virtual-assistant/dist/dynamic/ChatbotWelcomePrompt';
 import ChatbotFooter, { ChatbotFootnote } from '@patternfly/virtual-assistant/dist/dynamic/ChatbotFooter';
@@ -8,10 +8,31 @@ import MessageBar from '@patternfly/virtual-assistant/dist/dynamic/MessageBar';
 import MessageBox from '@patternfly/virtual-assistant/dist/dynamic/MessageBox';
 import Message, { MessageProps } from '@patternfly/virtual-assistant/dist/dynamic/Message';
 import FileDropZone from '@patternfly/virtual-assistant/dist/dynamic/FileDropZone';
-import { Alert, AlertActionCloseButton, DropEvent } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertActionCloseButton,
+  Brand,
+  Bullseye,
+  DropdownGroup,
+  DropdownItem,
+  DropdownList,
+  DropEvent
+} from '@patternfly/react-core';
 import FileDetailsLabel from '@patternfly/virtual-assistant/dist/dynamic/FileDetailsLabel';
 import PreviewAttachment from '@patternfly/virtual-assistant/dist/dynamic/PreviewAttachment';
 import AttachmentEdit from '@patternfly/virtual-assistant/dist/dynamic/AttachmentEdit';
+import ChatbotHeader, {
+  ChatbotHeaderMenu,
+  ChatbotHeaderTitle,
+  ChatbotHeaderActions,
+  ChatbotHeaderSelectorDropdown,
+  ChatbotHeaderOptionsDropdown
+} from '@patternfly/virtual-assistant/dist/dynamic/ChatbotHeader';
+import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
+import OpenDrawerRightIcon from '@patternfly/react-icons/dist/esm/icons/open-drawer-right-icon';
+import OutlinedWindowRestoreIcon from '@patternfly/react-icons/dist/esm/icons/outlined-window-restore-icon';
+import PFHorizontalLogoColor from '../ChatbotHeader/PF-HorizontalLogo-Color.svg';
+import PFHorizontalLogoReverse from '../ChatbotHeader/PF-HorizontalLogo-Reverse.svg';
 
 const footnoteProps = {
   label: 'Lightspeed uses AI. Check for mistakes.',
@@ -94,6 +115,23 @@ export const BasicDemo: React.FunctionComponent = () => {
   const [isEditModalOpen, setIsEditModalOpen] = React.useState<boolean>(false);
   const [currentModalData, setCurrentModalData] = React.useState<ModalData>();
   const [showAlert, setShowAlert] = React.useState<boolean>(false);
+  const [selectedModel, setSelectedModel] = React.useState('Granite 7B');
+  const [displayMode, setDisplayMode] = React.useState<ChatbotDisplayMode>(ChatbotDisplayMode.default);
+
+  const onSelectModel = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined
+  ) => {
+    setSelectedModel(value as string);
+  };
+
+  const onSelectDisplayMode = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined
+  ) => {
+    setDisplayMode(value as ChatbotDisplayMode);
+  };
+
   const handleSend = (message) => alert(message);
 
   // Attachments
@@ -166,9 +204,64 @@ export const BasicDemo: React.FunctionComponent = () => {
           setIsPreviewModalOpen(false);
         }}
       />
-      <Chatbot isVisible={chatbotVisible}>
-        <FileDropZone onFileDrop={handleFileDrop}>
+      <Chatbot isVisible={chatbotVisible} displayMode={displayMode}>
+        <FileDropZone onFileDrop={handleFileDrop} displayMode={displayMode}>
           <>
+            <ChatbotHeader>
+              <ChatbotHeaderMenu onMenuToggle={() => alert('Menu toggle clicked')} />
+              <ChatbotHeaderTitle>
+                <Bullseye>
+                  <div className="show-light">
+                    <Brand src={PFHorizontalLogoColor} alt="PatternFly" />
+                  </div>
+                  <div className="show-dark">
+                    <Brand src={PFHorizontalLogoReverse} alt="PatternFly" />
+                  </div>
+                </Bullseye>
+              </ChatbotHeaderTitle>
+              <ChatbotHeaderActions>
+                <ChatbotHeaderSelectorDropdown value={selectedModel} onSelect={onSelectModel}>
+                  <DropdownList>
+                    <DropdownItem value="Granite 7B" key="granite">
+                      Granite 7B
+                    </DropdownItem>
+                    <DropdownItem value="Llama 3.0" key="llama">
+                      Llama 3.0
+                    </DropdownItem>
+                    <DropdownItem value="Mistral 3B" key="mistral">
+                      Mistral 3B
+                    </DropdownItem>
+                  </DropdownList>
+                </ChatbotHeaderSelectorDropdown>
+                <ChatbotHeaderOptionsDropdown onSelect={onSelectDisplayMode}>
+                  <DropdownGroup label="Display mode">
+                    <DropdownList>
+                      <DropdownItem
+                        value={ChatbotDisplayMode.default}
+                        key="switchDisplayOverlay"
+                        icon={<OutlinedWindowRestoreIcon aria-hidden />}
+                      >
+                        <span>Overlay</span>
+                      </DropdownItem>
+                      <DropdownItem
+                        value={ChatbotDisplayMode.docked}
+                        key="switchDisplayDock"
+                        icon={<OpenDrawerRightIcon aria-hidden />}
+                      >
+                        <span>Dock to window</span>
+                      </DropdownItem>
+                      <DropdownItem
+                        value={ChatbotDisplayMode.fullscreen}
+                        key="switchDisplayFullscreen"
+                        icon={<ExpandIcon aria-hidden />}
+                      >
+                        <span>Fullscreen</span>
+                      </DropdownItem>
+                    </DropdownList>
+                  </DropdownGroup>
+                </ChatbotHeaderOptionsDropdown>
+              </ChatbotHeaderActions>
+            </ChatbotHeader>
             <ChatbotContent>
               {showAlert && (
                 <Alert

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachment.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachment.tsx
@@ -313,6 +313,7 @@ export const BasicDemo: React.FunctionComponent = () => {
           }}
           onDismiss={() => setCurrentModalData(undefined)}
           handleModalToggle={() => setIsPreviewModalOpen(false)}
+          displayMode={displayMode}
         />
       )}
       {currentModalData && (
@@ -325,6 +326,7 @@ export const BasicDemo: React.FunctionComponent = () => {
           }}
           onCancel={() => setCurrentModalData(undefined)}
           handleModalToggle={() => setIsEditModalOpen(false)}
+          displayMode={displayMode}
         />
       )}
     </>

--- a/packages/module/src/AttachmentEdit/AttachmentEdit.tsx
+++ b/packages/module/src/AttachmentEdit/AttachmentEdit.tsx
@@ -3,6 +3,7 @@
 // ============================================================================
 import React from 'react';
 import CodeModal from '../CodeModal';
+import { ChatbotDisplayMode } from '../Chatbot';
 
 export interface AttachmentEditProps {
   /** Text shown in code editor */
@@ -19,6 +20,8 @@ export interface AttachmentEditProps {
   isModalOpen: boolean;
   /** Title of modal */
   title?: string;
+  /** Display mode for the Chatbot parent; this influences the styles applied */
+  displayMode?: ChatbotDisplayMode;
 }
 
 export const AttachmentEdit: React.FunctionComponent<AttachmentEditProps> = ({
@@ -28,7 +31,8 @@ export const AttachmentEdit: React.FunctionComponent<AttachmentEditProps> = ({
   isModalOpen,
   onCancel,
   onSave,
-  title = 'Edit attachment'
+  title = 'Edit attachment',
+  displayMode = ChatbotDisplayMode.default
 }: AttachmentEditProps) => {
   const handleSave = (_event: React.MouseEvent | MouseEvent | KeyboardEvent, code) => {
     handleModalToggle(_event);
@@ -51,6 +55,7 @@ export const AttachmentEdit: React.FunctionComponent<AttachmentEditProps> = ({
       primaryActionBtn="Save"
       secondaryActionBtn="Cancel"
       title={title}
+      displayMode={displayMode}
     />
   );
 };

--- a/packages/module/src/Chatbot/Chatbot.scss
+++ b/packages/module/src/Chatbot/Chatbot.scss
@@ -15,7 +15,7 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
   font-size: var(--pf-t--chatbot--font-size);
   overflow: hidden;
-  z-index: var(--pf-t--global--z-index--2xl);
+  z-index: var(--pf-t--global--z-index--md);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 

--- a/packages/module/src/CodeModal/CodeModal.scss
+++ b/packages/module/src/CodeModal/CodeModal.scss
@@ -5,7 +5,7 @@
   inset-inline-end: var(--pf-t--global--spacer--lg);
   width: 30rem;
   height: 70vh;
-  z-index: 900; // tokens only go up to 600, which is what chatbot uses
+  background-color: var(--pf-t--chatbot--background);
 
   .pf-v6-c-modal-box__title {
     --pf-v6-c-modal-box__title--FontSize: var(--pf-t--global--font--size--heading--h2);
@@ -80,6 +80,42 @@
   }
 }
 
+// ============================================================================
+// Chatbot Display Mode - Fullscreen
+// ============================================================================
+.pf-chatbot__code-modal--fullscreen {
+  inset-block-end: 0;
+  inset-inline-end: 0;
+  width: 50%;
+  height: fit-content;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+// ============================================================================
+// Chatbot Display Mode - Default/Embedded
+// ============================================================================
+.pf-chatbot__code-modal--default,
+.pf-chatbot__code-modal--embedded {
+  box-shadow: unset;
+}
+
+// ============================================================================
+// Chatbot Display Mode - Docked
+// ============================================================================
+.pf-chatbot__code-modal--docked {
+  height: 100vh;
+  inset-block-end: 0;
+  inset-inline-end: 0;
+  border-radius: 0;
+  --pf-v6-c-modal-box--MaxHeight: 100vh;
+  box-shadow: unset;
+}
+
+// ============================================================================
+// Dark theme
+// ============================================================================
 .pf-v6-theme-dark {
   .pf-chatbot__code-modal {
     .pf-v6-c-code-editor__controls > div > button {
@@ -92,4 +128,11 @@
       color: #fff;
     }
   }
+}
+
+// ============================================================================
+// Backdrop
+// ============================================================================
+.pf-v6-c-backdrop.pf-chatbot__backdrop {
+  position: absolute;
 }

--- a/packages/module/src/CodeModal/CodeModal.tsx
+++ b/packages/module/src/CodeModal/CodeModal.tsx
@@ -8,6 +8,7 @@ import path from 'path';
 import { CodeEditor } from '@patternfly/react-code-editor';
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Stack, StackItem } from '@patternfly/react-core';
 import FileDetails, { extensionToLanguage } from '../FileDetails';
+import { ChatbotDisplayMode } from '../Chatbot';
 
 export interface CodeModalProps {
   /** Class applied to code editor */
@@ -36,6 +37,8 @@ export interface CodeModalProps {
   isModalOpen: boolean;
   /** Title of modal */
   title: string;
+  /** Display mode for the Chatbot parent; this influences the styles applied */
+  displayMode?: ChatbotDisplayMode;
 }
 
 export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
@@ -52,6 +55,7 @@ export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
   primaryActionBtn,
   secondaryActionBtn,
   title,
+  displayMode = ChatbotDisplayMode.default,
   ...props
 }: CodeModalProps) => {
   const [newCode, setNewCode] = useState(code);
@@ -82,15 +86,25 @@ export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
     }
   };
 
-  return (
+  /* eslint-disable indent */
+  const getHeight = (displayMode: ChatbotDisplayMode) => {
+    switch (displayMode) {
+      case ChatbotDisplayMode.docked:
+        return '100vh';
+      default:
+        return '45vh';
+    }
+  };
+  /* eslint-enable indent */
+
+  const modal = (
     <Modal
       isOpen={isModalOpen}
       onClose={handleModalToggle}
       ouiaId="CodeModal"
       aria-labelledby="code-modal-title"
       aria-describedby="code-modal"
-      width="25%"
-      className="pf-chatbot__code-modal"
+      className={`pf-chatbot__code-modal pf-chatbot__code-modal--${displayMode}`}
     >
       <ModalHeader title={title} labelId="code-modal-title" />
       <ModalBody id="code-modal-body">
@@ -110,7 +124,7 @@ export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
               onEditorDidMount={onEditorDidMount}
               onCodeChange={onCodeChange}
               className={codeEditorClassName}
-              height="45vh"
+              height={getHeight(displayMode)}
               {...props}
             />
           </StackItem>
@@ -126,6 +140,11 @@ export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
       </ModalFooter>
     </Modal>
   );
+
+  if (displayMode === ChatbotDisplayMode.fullscreen && isModalOpen) {
+    return <div className="pf-v6-c-backdrop pf-chatbot__backdrop">{modal}</div>;
+  }
+  return modal;
 };
 
 export default CodeModal;

--- a/packages/module/src/FileDropZone/FileDropZone.scss
+++ b/packages/module/src/FileDropZone/FileDropZone.scss
@@ -1,5 +1,6 @@
 .pf-chatbot__dropzone {
   height: calc(70vh - var(--pf-t--global--spacer--lg) * 2);
+  gap: unset; // default PF value causes alignment issues when this is used to wrap other components, notably in the footer
 
   .pf-v6-c-multiple-file-upload__main {
     background: rgba(224, 224, 224, 0.5);

--- a/packages/module/src/FileDropZone/FileDropZone.scss
+++ b/packages/module/src/FileDropZone/FileDropZone.scss
@@ -49,6 +49,11 @@
   }
 }
 
+.pf-chatbot__dropzone--fullscreen,
+.pf-chatbot__dropzone--docked {
+  height: 100vh;
+}
+
 /** Used in example only */
 .pf-chatbot__file-drop-zone-example {
   border: var(--pf-t--global--border--width--divider--default) solid var(--pf-t--global--border--color--default);

--- a/packages/module/src/FileDropZone/FileDropZone.tsx
+++ b/packages/module/src/FileDropZone/FileDropZone.tsx
@@ -1,5 +1,6 @@
 import { DropEvent, MultipleFileUpload, MultipleFileUploadMain } from '@patternfly/react-core';
 import React from 'react';
+import { ChatbotDisplayMode } from '../Chatbot';
 
 export interface FileDropZoneProps {
   /** Content displayed when the drop zone is not currently in use */
@@ -10,6 +11,8 @@ export interface FileDropZoneProps {
   infoText?: string;
   /** When files are dropped or uploaded this callback will be called with all accepted files */
   onFileDrop: (event: DropEvent, data: File[]) => void;
+  /** Display mode for the Chatbot parent; this influences the styles applied */
+  displayMode?: ChatbotDisplayMode;
 }
 
 const FileDropZone: React.FunctionComponent<FileDropZoneProps> = ({
@@ -17,6 +20,7 @@ const FileDropZone: React.FunctionComponent<FileDropZoneProps> = ({
   className,
   infoText = 'Maximum file size is 25 MB',
   onFileDrop,
+  displayMode = ChatbotDisplayMode.default,
   ...props
 }: FileDropZoneProps) => {
   const [showDropZone, setShowDropZone] = React.useState(false);
@@ -52,7 +56,7 @@ const FileDropZone: React.FunctionComponent<FileDropZoneProps> = ({
       onDragEnter={() => setShowDropZone(true)}
       onDragLeave={() => setShowDropZone(false)}
       onFileDrop={onFileDrop}
-      className={`pf-chatbot__dropzone ${className ? className : ''}`}
+      className={`pf-chatbot__dropzone pf-chatbot__dropzone--${displayMode} ${className ? className : ''}`}
     >
       {showDropZone ? renderDropZone() : children}
     </MultipleFileUpload>

--- a/packages/module/src/MessageBar/MessageBar.scss
+++ b/packages/module/src/MessageBar/MessageBar.scss
@@ -15,7 +15,6 @@
 
   display: flex;
   flex-wrap: wrap;
-  flex-grow: 1;
   align-items: flex-end;
   justify-content: flex-end;
   background-color: var(--pf-t--global--background--color--primary--default);
@@ -61,7 +60,7 @@
   line-height: 1.5rem;
   max-height: 12rem;
   overflow-y: auto;
-  display:block !important;
+  display: block !important;
 
   .pf-v6-c-form-control__textarea:focus-visible {
     outline: none;

--- a/packages/module/src/MessageBox/JumpButton.scss
+++ b/packages/module/src/MessageBox/JumpButton.scss
@@ -19,7 +19,7 @@
     box-shadow var(--pf-t--chatbot--timing-function) var(--pf-t--global--motion--duration--sm),
     transform var(--pf-t--chatbot--timing-function) var(--pf-t--global--motion--duration--md),
     opacity var(--pf-t--chatbot--timing-function) var(--pf-t--global--motion--duration--md);
-  z-index: var(--pf-t--global--z-index--2xl);
+  z-index: var(--pf-t--global--z-index--md);
 
   &:hover,
   &:focus {

--- a/packages/module/src/PreviewAttachment/PreviewAttachment.tsx
+++ b/packages/module/src/PreviewAttachment/PreviewAttachment.tsx
@@ -3,6 +3,7 @@
 // ============================================================================
 import React from 'react';
 import CodeModal from '../CodeModal';
+import { ChatbotDisplayMode } from '../Chatbot';
 
 export interface PreviewAttachmentProps {
   /** Text shown in code editor */
@@ -19,6 +20,8 @@ export interface PreviewAttachmentProps {
   isModalOpen: boolean;
   /** Title of modal */
   title?: string;
+  /** Display mode for the Chatbot parent; this influences the styles applied */
+  displayMode?: ChatbotDisplayMode;
 }
 
 export const PreviewAttachment: React.FunctionComponent<PreviewAttachmentProps> = ({
@@ -28,7 +31,8 @@ export const PreviewAttachment: React.FunctionComponent<PreviewAttachmentProps> 
   isModalOpen,
   onDismiss = undefined,
   onEdit,
-  title = 'Preview attachment'
+  title = 'Preview attachment',
+  displayMode = ChatbotDisplayMode.default
 }: PreviewAttachmentProps) => {
   const handleEdit = (_event: React.MouseEvent | MouseEvent | KeyboardEvent) => {
     handleModalToggle(_event);
@@ -55,6 +59,7 @@ export const PreviewAttachment: React.FunctionComponent<PreviewAttachmentProps> 
       secondaryActionBtn="Dismiss"
       title={title}
       isReadOnly
+      displayMode={displayMode}
     />
   );
 };


### PR DESCRIPTION
Working on integrating display mode feature into FileDropZone/CodeModal so we can add the header into the attachment demos. This does not include really include many design updates. The purpose is mostly just to integrate display mode and update the modal behavior so it makes sense.

Will fix https://github.com/patternfly/virtual-assistant/issues/128 eventually.