### PR TITLE
fix(TextMessage): Always override text color in user message bubbles

### DIFF
--- a/packages/module/src/Message/TextMessage/TextMessage.scss
+++ b/packages/module/src/Message/TextMessage/TextMessage.scss
@@ -22,5 +22,12 @@
   .pf-chatbot__message-text {
     background-color: var(--pf-t--chatbot-message--type--background--color--primary);
     color: var(--pf-t--chatbot-message--type--text--color--primary);
+
+    .pf-v6-c-content,
+    .pf-v6-c-content--small,
+    .pf-v6-c-content--blockquote,
+    a {
+      color: var(--pf-t--chatbot-message--type--text--color--primary);
+    }
   }
 }


### PR DESCRIPTION
If you placed .pf-v6-c-content inside of the blue user text box, .pf-v6-c-content text styles would override the blue user text box styles. This could cause black text inside of the blue box instead of white text.

Michael Coker suggested a more broad approach here if we want to go back to that in the future: https://patternfly.slack.com/archives/C03LQ25DDLN/p1726153079441679?thread_ts=1726148417.697719&cid=C03LQ25DDLN. It sounds like we should go narrow so we don't interfere with other PatternFly components we may pull in as we add more message subtypes. 

This should hopefully make everything white. I pulled in some samples from Michael Coker here: https://codepen.io/mcoker/pen/abgxBOa?editors=1100 into the Message component and went through them to make sure they looked ok. I added additional target classes for the ones that were off-color so we can have a slightly broader reach.

We may wind up with additional bugs down the line as this is used and abused more broadly in products over time.

Fixes https://github.com/patternfly/virtual-assistant/issues/118.