### PR TITLE
fix(ChatbotWelcomePrompt): Sample prompts should be a row on fullscreen

### DIFF
--- a/packages/module/src/ChatbotWelcomePrompt/ChatbotWelcomePrompt.scss
+++ b/packages/module/src/ChatbotWelcomePrompt/ChatbotWelcomePrompt.scss
@@ -18,4 +18,20 @@
   .pf-chatbot__question {
     color: var(--pf-t--global--text--color--subtle);
   }
+
+  .pf-chatbot__prompt-suggestions > * {
+    flex: 1;
+  }
+}
+
+// ============================================================================
+// Chatbot Display Mode - Fullscreen
+// ============================================================================
+.pf-chatbot--fullscreen {
+  .pf-chatbot--layout--welcome {
+    .pf-chatbot__prompt-suggestions {
+      flex-direction: row;
+      align-items: baseline;
+    }
+  }
 }

--- a/packages/module/src/ChatbotWelcomePrompt/ChatbotWelcomePrompt.tsx
+++ b/packages/module/src/ChatbotWelcomePrompt/ChatbotWelcomePrompt.tsx
@@ -44,11 +44,7 @@ export const ChatbotWelcomePrompt: React.FunctionComponent<ChatbotWelcomePromptP
       <span className="pf-chatbot__question">{description}</span>
     </Content>
 
-    <Flex
-      className="pf-chatbot__prompt-suggestions"
-      direction={{ default: 'row', lg: 'column' }}
-      gap={{ default: 'gapLg' }}
-    >
+    <Flex className="pf-chatbot__prompt-suggestions" direction={{ default: 'column' }} gap={{ default: 'gapLg' }}>
       {prompts?.map((prompt) => (
         <Card key={prompt.message} className="pf-chatbot__prompt-suggestion" isClickable>
           <CardHeader


### PR DESCRIPTION
Rohit's last PR had the sample prompts side by side full screen. It looks like we lost this in the first CSS refactor. I am restoring that functionality. Rohit's PR was https://github.com/patternfly/virtual-assistant/pull/94. I used it as a point of comparison for the behavior of the welcome prompts.

Fixes https://github.com/patternfly/virtual-assistant/issues/136