### PR TITLE
fix(FileDetailsLabel): Kayla wants to change the background

### DIFF
--- a/packages/module/src/FileDetailsLabel/FileDetailsLabel.scss
+++ b/packages/module/src/FileDetailsLabel/FileDetailsLabel.scss
@@ -3,7 +3,6 @@
     var(--pf-t--global--spacer--md);
   gap: var(--pf-t--global--spacer--sm);
   --pf-v6-c-label--m-clickable--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
-  border: var(--pf-t--global--border--width--strong) solid transparent;
 }
 
 .pf-v6-c-label.pf-chatbot__file-label {
@@ -19,7 +18,6 @@
 .pf-v6-theme-dark {
   .pf-v6-c-label.pf-chatbot__file-label {
     --pf-v6-c-label--m-clickable--hover--Color: var(--pf-t--global--text--color--regular);
-    --pf-v6-c-label--m-clickable--hover--BackgroundColor: var(--pf-t--global--background--color--secondary--hover);
   }
 
   .pf-chatbot__file-label > .pf-v6-c-label__actions > .pf-v6-c-button.pf-m-plain > .pf-v6-c-button__icon {
@@ -29,9 +27,8 @@
 
 .pf-chatbot__file-label.pf-m-clickable:hover,
 .pf-chatbot__file-label.pf-m-clickable:focus-within {
-  border: var(--pf-t--global--border--width--strong) solid var(--pf-t--global--border--color--on-secondary);
-  --pf-v6-c-label--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
-  --pf-v6-c-label--m-clickable--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
+  --pf-v6-c-label--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
+  --pf-v6-c-label--m-clickable--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
 
   .pf-chatbot__code-icon {
     color: var(--pf-t--global--icon--color--status--custom--hover);

--- a/packages/module/src/FileDetailsLabel/FileDetailsLabel.tsx
+++ b/packages/module/src/FileDetailsLabel/FileDetailsLabel.tsx
@@ -1,7 +1,8 @@
 import React, { PropsWithChildren } from 'react';
-import { Flex, FlexItem, Label } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Label } from '@patternfly/react-core';
 import FileDetails from '../FileDetails';
 import { Spinner } from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 
 interface FileDetailsLabelProps {
   /** Name of file, including extension */
@@ -12,15 +13,32 @@ interface FileDetailsLabelProps {
   onClick?: (event: React.MouseEvent) => void;
   /** Callback function for when close button is clicked */
   onClose?: (event: React.MouseEvent) => void;
+  /** Aria label for close button */
+  closeButtonAriaLabel?: string;
 }
 
 export const FileDetailsLabel = ({
   fileName,
   isLoading,
   onClick = undefined,
-  onClose = undefined
+  onClose = undefined,
+  closeButtonAriaLabel
 }: PropsWithChildren<FileDetailsLabelProps>) => (
-  <Label className="pf-chatbot__file-label" onClose={onClose} onClick={onClick} textMaxWidth="370px">
+  <Label
+    className="pf-chatbot__file-label"
+    onClose={onClose}
+    closeBtn={
+      <Button
+        type="button"
+        variant="plain"
+        onClick={onClose}
+        aria-label={closeButtonAriaLabel ?? `Close ${fileName}`}
+        icon={<TimesIcon />}
+      />
+    }
+    onClick={onClick}
+    textMaxWidth="370px"
+  >
     <Flex
       justifyContent={{ default: 'justifyContentCenter' }}
       alignItems={{ default: 'alignItemsCenter' }}


### PR DESCRIPTION
Kayla and Lucia met and decided on a different approach to FileDetailsLabel - updating that here.

|Before|After|
|-|-|
|<img width="215" alt="Screenshot 2024-09-19 at 2 04 50 PM" src="https://github.com/user-attachments/assets/3f51927d-f1d4-4588-a5e9-a547147372be">|<img width="234" alt="Screenshot 2024-09-19 at 2 03 03 PM" src="https://github.com/user-attachments/assets/c7733f2a-6f8a-427b-a811-e4c6270a8370">
|<img width="200" alt="Screenshot 2024-09-19 at 2 04 56 PM" src="https://github.com/user-attachments/assets/262f206d-4a66-4e89-8a49-d54e6324c49d">|<img width="215" alt="Screenshot 2024-09-19 at 2 03 12 PM" src="https://github.com/user-attachments/assets/f2587974-ea21-49dd-b508-ce001e628d90">
