### PR TITLE
chore(Chatbot/ChatbotAttachment): Show selected state on display mode dropdowns

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Chatbot/Chatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Chatbot/Chatbot.tsx
@@ -171,6 +171,7 @@ export const BasicDemo: React.FunctionComponent = () => {
                     value={ChatbotDisplayMode.default}
                     key="switchDisplayOverlay"
                     icon={<OutlinedWindowRestoreIcon aria-hidden />}
+                    isSelected={displayMode === ChatbotDisplayMode.default}
                   >
                     <span>Overlay</span>
                   </DropdownItem>
@@ -178,6 +179,7 @@ export const BasicDemo: React.FunctionComponent = () => {
                     value={ChatbotDisplayMode.docked}
                     key="switchDisplayDock"
                     icon={<OpenDrawerRightIcon aria-hidden />}
+                    isSelected={displayMode === ChatbotDisplayMode.docked}
                   >
                     <span>Dock to window</span>
                   </DropdownItem>
@@ -185,6 +187,7 @@ export const BasicDemo: React.FunctionComponent = () => {
                     value={ChatbotDisplayMode.fullscreen}
                     key="switchDisplayFullscreen"
                     icon={<ExpandIcon aria-hidden />}
+                    isSelected={displayMode === ChatbotDisplayMode.fullscreen}
                   >
                     <span>Fullscreen</span>
                   </DropdownItem>

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachment.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachment.tsx
@@ -240,6 +240,7 @@ export const BasicDemo: React.FunctionComponent = () => {
                         value={ChatbotDisplayMode.default}
                         key="switchDisplayOverlay"
                         icon={<OutlinedWindowRestoreIcon aria-hidden />}
+                        isSelected={displayMode === ChatbotDisplayMode.default}
                       >
                         <span>Overlay</span>
                       </DropdownItem>
@@ -247,6 +248,7 @@ export const BasicDemo: React.FunctionComponent = () => {
                         value={ChatbotDisplayMode.docked}
                         key="switchDisplayDock"
                         icon={<OpenDrawerRightIcon aria-hidden />}
+                        isSelected={displayMode === ChatbotDisplayMode.docked}
                       >
                         <span>Dock to window</span>
                       </DropdownItem>
@@ -254,6 +256,7 @@ export const BasicDemo: React.FunctionComponent = () => {
                         value={ChatbotDisplayMode.fullscreen}
                         key="switchDisplayFullscreen"
                         icon={<ExpandIcon aria-hidden />}
+                        isSelected={displayMode === ChatbotDisplayMode.fullscreen}
                       >
                         <span>Fullscreen</span>
                       </DropdownItem>


### PR DESCRIPTION
Mark's original design called for us to show which display mode was selected in the dropdown. This was reproduced in Kayla's work. This brings us up to parity with both. Kayla wants to continue using a default PF dropdown for now.

<img width="244" alt="Screenshot 2024-09-19 at 3 45 09 PM" src="https://github.com/user-attachments/assets/49780662-8b13-454a-8606-7a16bd99e540">
