### PR TITLE
fix(docs): Add polyfill for path

### DIFF
--- a/config/webpack.cy.config.js
+++ b/config/webpack.cy.config.js
@@ -14,11 +14,11 @@ const JSConfig = {
             jsc: {
               parser: {
                 syntax: 'typescript',
-                tsx: true,
-              },
-            },
-          },
-        },
+                tsx: true
+              }
+            }
+          }
+        }
       },
       {
         test: /\.s?[ac]ss$/,
@@ -28,40 +28,43 @@ const JSConfig = {
           {
             loader: 'sass-loader',
             options: {
-              sourceMap: true,
-            },
-          },
-        ],
+              sourceMap: true
+            }
+          }
+        ]
       },
       {
         test: /\.(jpe?g|svg|png|gif|ico|eot|ttf|woff2?)(\?v=\d+\.\d+\.\d+)?$/i,
-        type: 'asset/resource',
-      },
-    ],
+        type: 'asset/resource'
+      }
+    ]
   },
   resolve: {
-    extensions: [ '.tsx', '.ts', '.js' ],
+    extensions: ['.tsx', '.ts', '.js'],
+    fallback: {
+      path: require.resolve('path-browserify')
+    }
   },
   output: {
     filename: 'bundle.js',
     hashFunction: 'xxhash64',
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(__dirname, 'dist')
   },
   cache: {
     type: 'filesystem',
     buildDependencies: {
-      config: [ __filename ],
+      config: [__filename]
     },
-    cacheDirectory: path.resolve(__dirname, '../.cypress-cache'),
+    cacheDirectory: path.resolve(__dirname, '../.cypress-cache')
   },
   stats: {
-    errorDetails: true,
+    errorDetails: true
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: '[name].[contenthash].css',
-    }),
-  ],
+      filename: '[name].[contenthash].css'
+    })
+  ]
 };
 
 module.exports = JSConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "path-browserify": "^1.0.1",
         "react-dropzone": "^14.2.3"
       },
       "devDependencies": {
@@ -20631,7 +20632,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "whatwg-fetch": "^3.6.20"
   },
   "dependencies": {
+    "path-browserify": "^1.0.1",
     "react-dropzone": "^14.2.3"
   }
 }


### PR DESCRIPTION
Webpack 5 doesn't have polyfills for path anymore; this adds a polyfill so users don't have to do this on their side.