### PR TITLE
fix(Header): Refactor into composable grid

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotHeader/ChatbotHeader.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotHeader/ChatbotHeader.md
@@ -13,6 +13,7 @@ source: react
 propComponents:
   [
     'ChatbotHeader',
+    'ChatbotHeaderMain',
     'ChatbotHeaderMenu',
     'ChatbotHeaderActions',
     'ChatbotHeaderTitle',
@@ -23,6 +24,7 @@ propComponents:
 
 import {
 ChatbotHeader,
+ChatbotHeaderMain,
 ChatbotHeaderMenu,
 ChatbotHeaderActions,
 ChatbotHeaderTitle,

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotHeader/ChatbotHeaderBasic.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotHeader/ChatbotHeaderBasic.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
-import { Brand, Bullseye, DropdownGroup, DropdownItem, DropdownList, Title } from '@patternfly/react-core';
+import {
+  Brand,
+  Bullseye,
+  Checkbox,
+  DropdownGroup,
+  DropdownItem,
+  DropdownList,
+  FormGroup,
+  Stack,
+  Title
+} from '@patternfly/react-core';
 import {
   ChatbotHeader,
+  ChatbotHeaderMain,
   ChatbotHeaderMenu,
   ChatbotHeaderActions,
   ChatbotHeaderTitle,
@@ -18,6 +29,12 @@ import PFHorizontalLogoReverse from './PF-HorizontalLogo-Reverse.svg';
 
 export const BasicDemo: React.FunctionComponent = () => {
   const [selectedModel, setSelectedModel] = React.useState('Granite Code 7B');
+  const [showAll, setShowAll] = React.useState<boolean>(true);
+  const [showMenu, setShowMenu] = React.useState<boolean>(true);
+  const [showLogo, setShowLogo] = React.useState<boolean>(false);
+  const [showCenteredLogo, setShowCenteredLogo] = React.useState<boolean>(true);
+  const [showSelectorDropdown, setShowSelectorDropdown] = React.useState<boolean>(true);
+  const [showOptionsDropdown, setShowOptionsDropdown] = React.useState<boolean>(true);
 
   const onSelectModel = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
@@ -26,64 +43,147 @@ export const BasicDemo: React.FunctionComponent = () => {
     setSelectedModel(value as string);
   };
 
+  const title = (
+    <>
+      <div className="show-light">
+        <Brand src={PFHorizontalLogoColor} alt="PatternFly" style={{ marginRight: '10px' }} />
+      </div>
+      <div className="show-dark">
+        <Brand src={PFHorizontalLogoReverse} alt="PatternFly" style={{ marginRight: '10px' }} />
+      </div>
+      <Title headingLevel="h1" size="2xl">
+        Chatbot Extension
+      </Title>
+    </>
+  );
+
   return (
-    <ChatbotHeader>
-      <ChatbotHeaderMenu onMenuToggle={() => alert('Menu toggle clicked')} />
-      <ChatbotHeaderTitle>
-        <Bullseye>
-          <div className="show-light">
-            <Brand src={PFHorizontalLogoColor} alt="PatternFly" style={{ marginRight: '10px' }} />
-          </div>
-          <div className="show-dark">
-            <Brand src={PFHorizontalLogoReverse} alt="PatternFly" style={{ marginRight: '10px' }} />
-          </div>
-          <Title headingLevel="h1" size="2xl">
-            Chatbot Extension
-          </Title>
-        </Bullseye>
-      </ChatbotHeaderTitle>
-      <ChatbotHeaderActions>
-        <ChatbotHeaderSelectorDropdown value={selectedModel} onSelect={onSelectModel}>
-          <DropdownList>
-            <DropdownItem value="Granite Code 7B" key="granite">
-              Granite Code 7B
-            </DropdownItem>
-            <DropdownItem value="Llama 3.0" key="llama">
-              Llama 3.0
-            </DropdownItem>
-            <DropdownItem value="Mistral 3B" key="mistral">
-              Mistral 3B
-            </DropdownItem>
-          </DropdownList>
-        </ChatbotHeaderSelectorDropdown>
-        <ChatbotHeaderOptionsDropdown>
-          <DropdownGroup label="Display mode">
-            <DropdownList>
-              <DropdownItem
-                value={ChatbotDisplayMode.default}
-                key="switchDisplayOverlay"
-                icon={<OutlinedWindowRestoreIcon aria-hidden />}
-              >
-                <span>Overlay</span>
-              </DropdownItem>
-              <DropdownItem
-                value={ChatbotDisplayMode.docked}
-                key="switchDisplayDock"
-                icon={<OpenDrawerRightIcon aria-hidden />}
-              >
-                <span>Dock to window</span>
-              </DropdownItem>
-              <DropdownItem
-                value={ChatbotDisplayMode.fullscreen}
-                key="switchDisplayFullscreen"
-                icon={<ExpandIcon aria-hidden />}
-              >
-                <span>Fullscreen</span>
-              </DropdownItem>
-            </DropdownList>
-          </DropdownGroup>
-        </ChatbotHeaderOptionsDropdown>
-      </ChatbotHeaderActions>
-    </ChatbotHeader>
+    <Stack hasGutter>
+      <FormGroup role="radiogroup" isInline fieldId="basic-form-radio-group" label="Variant">
+        <Checkbox
+          isChecked={showMenu && showCenteredLogo && showSelectorDropdown && showOptionsDropdown}
+          onChange={() => {
+            setShowMenu(true);
+            setShowCenteredLogo(true);
+            setShowSelectorDropdown(true);
+            setShowOptionsDropdown(true);
+            showLogo && setShowLogo(false);
+          }}
+          name="basic-inline-radio"
+          label="All"
+          id="all"
+        />
+        <Checkbox
+          isChecked={showMenu}
+          onChange={() => {
+            setShowMenu(!showMenu);
+            showAll && setShowAll(!showAll);
+          }}
+          name="basic-inline-radio"
+          label="With menu"
+          id="menu"
+        />
+        <Checkbox
+          isChecked={showLogo}
+          onChange={() => {
+            setShowLogo(!showLogo);
+            showCenteredLogo && setShowCenteredLogo(!showCenteredLogo);
+          }}
+          name="basic-inline-radio"
+          label="With left-aligned logo"
+          id="logo"
+        />
+        <Checkbox
+          isChecked={showCenteredLogo}
+          onChange={() => {
+            setShowCenteredLogo(!showCenteredLogo);
+            showLogo && setShowLogo(!showLogo);
+            showAll && setShowAll(!showAll);
+          }}
+          name="basic-inline-radio"
+          label="With centered logo"
+          id="logo-centered"
+        />
+        <Checkbox
+          isChecked={showSelectorDropdown}
+          onChange={() => {
+            setShowSelectorDropdown(!showSelectorDropdown);
+            showAll && setShowAll(!showAll);
+          }}
+          name="basic-inline-radio"
+          label="With selector dropdown"
+          id="selector-dropdown"
+        />
+        <Checkbox
+          isChecked={showOptionsDropdown}
+          onChange={() => {
+            setShowOptionsDropdown(!showOptionsDropdown);
+            showAll && setShowAll(!showAll);
+          }}
+          name="basic-inline-radio"
+          label="With options dropdown"
+          id="options-dropdown"
+        />
+      </FormGroup>
+
+      <ChatbotHeader>
+        {(showMenu || showLogo || showCenteredLogo) && (
+          <ChatbotHeaderMain>
+            {showMenu && <ChatbotHeaderMenu onMenuToggle={() => alert('Menu toggle clicked')} />}
+            {(showLogo || showCenteredLogo) && (
+              <ChatbotHeaderTitle>{showCenteredLogo ? <Bullseye>{title}</Bullseye> : title}</ChatbotHeaderTitle>
+            )}
+          </ChatbotHeaderMain>
+        )}
+        {(showSelectorDropdown || showOptionsDropdown) && (
+          <ChatbotHeaderActions>
+            {showSelectorDropdown && (
+              <ChatbotHeaderSelectorDropdown value={selectedModel} onSelect={onSelectModel}>
+                <DropdownList>
+                  <DropdownItem value="Granite Code 7B" key="granite">
+                    Granite Code 7B
+                  </DropdownItem>
+                  <DropdownItem value="Llama 3.0" key="llama">
+                    Llama 3.0
+                  </DropdownItem>
+                  <DropdownItem value="Mistral 3B" key="mistral">
+                    Mistral 3B
+                  </DropdownItem>
+                </DropdownList>
+              </ChatbotHeaderSelectorDropdown>
+            )}
+            {showOptionsDropdown && (
+              <ChatbotHeaderOptionsDropdown>
+                <DropdownGroup label="Display mode">
+                  <DropdownList>
+                    <DropdownItem
+                      value={ChatbotDisplayMode.default}
+                      key="switchDisplayOverlay"
+                      icon={<OutlinedWindowRestoreIcon aria-hidden />}
+                    >
+                      <span>Overlay</span>
+                    </DropdownItem>
+                    <DropdownItem
+                      value={ChatbotDisplayMode.docked}
+                      key="switchDisplayDock"
+                      icon={<OpenDrawerRightIcon aria-hidden />}
+                    >
+                      <span>Dock to window</span>
+                    </DropdownItem>
+                    <DropdownItem
+                      value={ChatbotDisplayMode.fullscreen}
+                      key="switchDisplayFullscreen"
+                      icon={<ExpandIcon aria-hidden />}
+                    >
+                      <span>Fullscreen</span>
+                    </DropdownItem>
+                  </DropdownList>
+                </DropdownGroup>
+              </ChatbotHeaderOptionsDropdown>
+            )}
+          </ChatbotHeaderActions>
+        )}
+      </ChatbotHeader>
+    </Stack>
   );
 };

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/AttachmentDemos.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/AttachmentDemos.md
@@ -30,6 +30,7 @@ import PFHorizontalLogoColor from '../ChatbotHeader/PF-HorizontalLogo-Color.svg'
 import PFHorizontalLogoReverse from '../ChatbotHeader/PF-HorizontalLogo-Reverse.svg';
 import ChatbotHeader, {
 ChatbotHeaderMenu,
+ChatbotHeaderMain,
 ChatbotHeaderTitle,
 ChatbotHeaderActions,
 ChatbotHeaderSelectorDropdown,

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/Chatbot.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/Chatbot.md
@@ -35,6 +35,7 @@ import MessageBox from '@patternfly/virtual-assistant/dist/dynamic/MessageBox';
 import Message from '@patternfly/virtual-assistant/dist/dynamic/Message';
 
 import ChatbotHeader, {
+ChatbotHeaderMain,
 ChatbotHeaderMenu,
 ChatbotHeaderTitle,
 ChatbotHeaderActions,

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/Chatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/Chatbot.tsx
@@ -12,6 +12,7 @@ import MessageBox from '@patternfly/virtual-assistant/dist/dynamic/MessageBox';
 import Message from '@patternfly/virtual-assistant/dist/dynamic/Message';
 import ChatbotHeader, {
   ChatbotHeaderMenu,
+  ChatbotHeaderMain,
   ChatbotHeaderTitle,
   ChatbotHeaderActions,
   ChatbotHeaderSelectorDropdown,
@@ -155,10 +156,12 @@ export const ChatbotDemo: React.FunctionComponent = () => {
       />
       <Chatbot isVisible={chatbotVisible} displayMode={displayMode}>
         <ChatbotHeader>
-          <ChatbotHeaderMenu onMenuToggle={() => alert('Menu toggle clicked')} />
-          <ChatbotHeaderTitle>
-            {displayMode === ChatbotDisplayMode.fullscreen ? horizontalLogo : iconLogo}
-          </ChatbotHeaderTitle>
+          <ChatbotHeaderMain>
+            <ChatbotHeaderMenu onMenuToggle={() => alert('Menu toggle clicked')} />
+            <ChatbotHeaderTitle>
+              {displayMode === ChatbotDisplayMode.fullscreen ? horizontalLogo : iconLogo}
+            </ChatbotHeaderTitle>
+          </ChatbotHeaderMain>
           <ChatbotHeaderActions>
             <ChatbotHeaderSelectorDropdown value={selectedModel} onSelect={onSelectModel}>
               <DropdownList>

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachment.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachment.tsx
@@ -26,7 +26,8 @@ import ChatbotHeader, {
   ChatbotHeaderTitle,
   ChatbotHeaderActions,
   ChatbotHeaderSelectorDropdown,
-  ChatbotHeaderOptionsDropdown
+  ChatbotHeaderOptionsDropdown,
+  ChatbotHeaderMain
 } from '@patternfly/virtual-assistant/dist/dynamic/ChatbotHeader';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
 import OpenDrawerRightIcon from '@patternfly/react-icons/dist/esm/icons/open-drawer-right-icon';
@@ -223,10 +224,12 @@ export const BasicDemo: React.FunctionComponent = () => {
       <Chatbot isVisible={chatbotVisible} displayMode={displayMode}>
         <>
           <ChatbotHeader>
-            <ChatbotHeaderMenu onMenuToggle={() => alert('Menu toggle clicked')} />
-            <ChatbotHeaderTitle>
-              {displayMode === ChatbotDisplayMode.fullscreen ? horizontalLogo : iconLogo}
-            </ChatbotHeaderTitle>
+            <ChatbotHeaderMain>
+              <ChatbotHeaderMenu onMenuToggle={() => alert('Menu toggle clicked')} />
+              <ChatbotHeaderTitle>
+                {displayMode === ChatbotDisplayMode.fullscreen ? horizontalLogo : iconLogo}
+              </ChatbotHeaderTitle>
+            </ChatbotHeaderMain>
             <ChatbotHeaderActions>
               <ChatbotHeaderSelectorDropdown value={selectedModel} onSelect={onSelectModel}>
                 <DropdownList>

--- a/packages/module/src/Chatbot/Chatbot.scss
+++ b/packages/module/src/Chatbot/Chatbot.scss
@@ -5,7 +5,6 @@
   position: fixed;
   inset-block-end: var(--pf-t--global--spacer--800); // no associated semantic token
   inset-inline-end: var(--pf-t--global--spacer--lg);
-  padding: var(--pf-t--global--spacer--lg);
   display: grid;
   grid-template-rows: auto 1fr auto;
   grid-auto-rows: auto;

--- a/packages/module/src/ChatbotContent/ChatbotContent.scss
+++ b/packages/module/src/ChatbotContent/ChatbotContent.scss
@@ -13,10 +13,3 @@
     padding-right: 12rem;
   }
 }
-
-.pf-chatbot--docked {
-  .pf-chatbot__content {
-    padding-left: var(--pf-t--global--spacer--lg);
-    padding-right: var(--pf-t--global--spacer--lg);
-  }
-}

--- a/packages/module/src/ChatbotFooter/ChatbotFooter.scss
+++ b/packages/module/src/ChatbotFooter/ChatbotFooter.scss
@@ -6,7 +6,7 @@
 // ============================================================================
 .pf-chatbot__footer {
   --pf-chatbot__footer--RowGap: var(--pf-t--global--spacer--md);
-
+  padding: 0 var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--lg);
   background-color: var(--pf-t--chatbot--background);
   display: flex;
   flex-direction: column;

--- a/packages/module/src/ChatbotHeader/ChatbotHeader.scss
+++ b/packages/module/src/ChatbotHeader/ChatbotHeader.scss
@@ -42,10 +42,6 @@
     justify-self: end;
     display: flex;
     gap: var(--pf-t--global--spacer--sm);
-
-    .pf-v6-c-menu-toggle.pf-m-secondary {
-      width: 150px;
-    }
   }
 }
 
@@ -58,12 +54,6 @@
   }
   .pf-chatbot__header__divider {
     display: none;
-  }
-
-  .pf-chatbot__actions {
-    .pf-v6-c-menu-toggle.pf-m-secondary {
-      width: 200px;
-    }
   }
 }
 

--- a/packages/module/src/ChatbotHeader/ChatbotHeader.scss
+++ b/packages/module/src/ChatbotHeader/ChatbotHeader.scss
@@ -1,36 +1,51 @@
 // ============================================================================
 // Chatbot Header
 // ============================================================================
+.pf-chatbot__header-container {
+  display: grid;
+}
 .pf-chatbot__header {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--pf-t--global--spacer--sm);
   position: relative;
   background-color: var(--pf-t--chatbot--background);
   justify-content: space-between;
-  padding: var(--pf-t--global--spacer--xs) var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--xs)
-    var(--pf-t--global--spacer--sm);
+  padding: var(--pf-t--global--spacer--lg);
+
+  .pf-chatbot__header-main {
+    display: flex;
+    gap: var(--pf-t--global--spacer--sm);
+  }
 
   // Title -or- Brand
   .pf-chatbot__title {
     display: flex;
     align-items: center;
+    flex: 1;
+
     .pf-v6-l-bullseye {
-      flex: 1;
+      width: 100%;
     }
+
     img {
       max-height: 40px;
+      vertical-align: middle;
     }
   }
 
   .pf-chatbot__menu {
-    flex-shrink: 0;
+    justify-self: start;
   }
 
   .pf-chatbot__actions {
-    width: 218px;
-    flex-shrink: 0;
-    flex-grow: 0;
+    justify-self: end;
     display: flex;
-    justify-content: flex-end;
+    gap: var(--pf-t--global--spacer--sm);
+
+    .pf-v6-c-menu-toggle.pf-m-secondary {
+      width: 150px;
+    }
   }
 }
 
@@ -39,12 +54,16 @@
 // ============================================================================
 .pf-chatbot--fullscreen {
   .pf-chatbot__header {
-    padding: var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--4xl) var(--pf-t--global--spacer--lg)
-      var(--pf-t--global--spacer--4xl);
     background-color: var(--pf-t--global--background--color--primary--default);
   }
   .pf-chatbot__header__divider {
     display: none;
+  }
+
+  .pf-chatbot__actions {
+    .pf-v6-c-menu-toggle.pf-m-secondary {
+      width: 200px;
+    }
   }
 }
 
@@ -53,8 +72,6 @@
 // ============================================================================
 .pf-chatbot--docked {
   .pf-chatbot__header {
-    padding: var(--pf-t--global--spacer--md) var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--md)
-      var(--pf-t--global--spacer--lg);
     background-color: var(--pf-t--chatbot--background);
   }
   .pf-chatbot__header__divider {

--- a/packages/module/src/ChatbotHeader/ChatbotHeader.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Split, Flex, Divider } from '@patternfly/react-core';
+import { Divider } from '@patternfly/react-core';
 
 export interface ChatbotHeaderProps extends React.HTMLProps<HTMLDivElement> {
   /** Content to be displayed in the chatbot header */
@@ -11,15 +11,12 @@ export interface ChatbotHeaderProps extends React.HTMLProps<HTMLDivElement> {
 
 export const ChatbotHeader: React.FunctionComponent<ChatbotHeaderProps> = ({
   className,
-  children,
-  ...props
+  children
 }: ChatbotHeaderProps) => (
-  <Flex direction={{ default: 'column' }} rowGap={{ default: 'rowGapMd' }}>
-    <Split className={`pf-chatbot__header ${className ?? ''}`} hasGutter {...props}>
-      {children}
-    </Split>
+  <div className="pf-chatbot__header-container">
+    <div className={`pf-chatbot__header ${className ?? ''}`}>{children}</div>
     <Divider className="pf-chatbot__header__divider" />
-  </Flex>
+  </div>
 );
 
 export default ChatbotHeader;

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderActions.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderActions.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { Split, SplitItem } from '@patternfly/react-core';
-
 export interface ChatbotHeaderActionsProps {
   /** Content to be displayed in the chatbot header */
   children: React.ReactNode;
@@ -12,10 +10,6 @@ export interface ChatbotHeaderActionsProps {
 export const ChatbotHeaderActions: React.FunctionComponent<ChatbotHeaderActionsProps> = ({
   className,
   children
-}: ChatbotHeaderActionsProps) => (
-  <SplitItem className={`pf-chatbot__actions ${className || ''}`}>
-    <Split hasGutter>{children}</Split>
-  </SplitItem>
-);
+}: ChatbotHeaderActionsProps) => <div className={`pf-chatbot__actions ${className || ''}`}>{children}</div>;
 
 export default ChatbotHeaderActions;

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderMain.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderMain.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export interface ChatbotHeaderMainProps {
+  /** Custom classname for the header component */
+  className?: string;
+  /** Menu and/or chatbot header components */
+  children: React.ReactNode;
+}
+
+export const ChatbotHeaderMain: React.FunctionComponent<ChatbotHeaderMainProps> = ({
+  className,
+  children
+}: ChatbotHeaderMainProps) => <div className={`pf-chatbot__header-main ${className}`}>{children}</div>;
+
+export default ChatbotHeaderMain;

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderMenu.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, Icon, SplitItem, Tooltip, TooltipProps } from '@patternfly/react-core';
+import { Button, Icon, Tooltip, TooltipProps } from '@patternfly/react-core';
 import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 
 export interface ChatbotHeaderMenuProps {
@@ -17,7 +17,7 @@ export const ChatbotHeaderMenu: React.FunctionComponent<ChatbotHeaderMenuProps> 
   onMenuToggle,
   tooltipProps
 }: ChatbotHeaderMenuProps) => (
-  <SplitItem className={`pf-chatbot__menu ${className}`}>
+  <div className={`pf-chatbot__menu ${className}`}>
     <Tooltip content="Menu" position="bottom" {...tooltipProps}>
       <Button
         className="pf-chatbot__button--toggle-menu"
@@ -32,7 +32,7 @@ export const ChatbotHeaderMenu: React.FunctionComponent<ChatbotHeaderMenuProps> 
         }
       />
     </Tooltip>
-  </SplitItem>
+  </div>
 );
 
 export default ChatbotHeaderMenu;

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderSelectorDropdown.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderSelectorDropdown.tsx
@@ -39,7 +39,7 @@ export const ChatbotHeaderSelectorDropdown: React.FunctionComponent<ChatbotHeade
 
   return (
     <Dropdown
-      className={`pf-chatbot__options ${className ?? ''}`}
+      className={`pf-chatbot__selections ${className ?? ''}`}
       isOpen={isOptionsMenuOpen}
       onSelect={(e, value) => {
         onSelect?.(e, value);

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderTitle.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderTitle.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { SplitItem } from '@patternfly/react-core';
-
 export interface ChatbotHeaderTitleProps {
   /** Content to be displayed in the chatbot header */
   children: React.ReactNode;
@@ -12,10 +10,6 @@ export interface ChatbotHeaderTitleProps {
 export const ChatbotHeaderTitle: React.FunctionComponent<ChatbotHeaderTitleProps> = ({
   className,
   children
-}: ChatbotHeaderTitleProps) => (
-  <SplitItem isFilled className={`pf-chatbot__title ${className || ''}`}>
-    {children}
-  </SplitItem>
-);
+}: ChatbotHeaderTitleProps) => <div className={`pf-chatbot__title ${className || ''}`}>{children}</div>;
 
 export default ChatbotHeaderTitle;

--- a/packages/module/src/ChatbotHeader/index.ts
+++ b/packages/module/src/ChatbotHeader/index.ts
@@ -2,6 +2,7 @@ export { default } from './ChatbotHeader';
 
 export * from './ChatbotHeader';
 export * from './ChatbotHeaderActions';
+export * from './ChatbotHeaderMain';
 export * from './ChatbotHeaderMenu';
 export * from './ChatbotHeaderTitle';
 export * from './ChatbotHeaderOptionsDropdown';

--- a/packages/module/src/FileDropZone/FileDropZone.scss
+++ b/packages/module/src/FileDropZone/FileDropZone.scss
@@ -10,6 +10,9 @@
 
 .pf-chatbot__dropzone--visible.pf-chatbot__dropzone {
   margin-block-start: var(--pf-t--global--spacer--lg);
+  margin-block-end: var(--pf-t--global--spacer--lg);
+  margin-inline-start: var(--pf-t--global--spacer--lg);
+  margin-inline-end: var(--pf-t--global--spacer--lg);
 
   .pf-v6-c-multiple-file-upload__main {
     --pf-v6-c-multiple-file-upload__main--BorderWidth: var(--pf-t--global--border--width--regular);
@@ -21,14 +24,6 @@
     align-items: center;
     justify-content: center;
   }
-}
-
-.pf-chatbot__dropzone--visible.pf-chatbot__dropzone--fullscreen,
-.pf-chatbot__dropzone--visible.pf-chatbot__dropzone--docked {
-  margin-block-start: var(--pf-t--global--spacer--lg);
-  margin-block-end: var(--pf-t--global--spacer--lg);
-  margin-inline-start: var(--pf-t--global--spacer--lg);
-  margin-inline-end: var(--pf-t--global--spacer--lg);
 }
 
 /** Used in example only */

--- a/packages/module/src/MessageBox/MessageBox.scss
+++ b/packages/module/src/MessageBox/MessageBox.scss
@@ -6,8 +6,5 @@
   display: flex;
   flex-direction: column;
   row-gap: var(--pf-v6-l-flex--spacer--row--base);
+  padding: 0 var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--lg);
 }
-
-
-
-


### PR DESCRIPTION
I refactored the header into something more composable - the old header started to have problems if you dropped the menu bar. I added an example that lets you turn things on and off so it's more clear how that works. Also added to the two full-page demos with a menu bar.