### PR TITLE
fix(AttachButton/AttachmentMenu): Add input

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotAttachment/ChatbotAttachment.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotAttachment/ChatbotAttachment.md
@@ -19,6 +19,8 @@ import FileDetailsLabel from '@patternfly/virtual-assistant/dist/dynamic/FileDet
 import FileDropZone from '@patternfly/virtual-assistant/dist/dynamic/FileDropZone';
 import { PreviewAttachment } from '@patternfly/virtual-assistant/dist/dynamic/PreviewAttachment';
 
+We are using [react-dropzone](https://react-dropzone.js.org) for opening the file dialog and handling drag and drop. It does not process files or provide any way to make HTTP requests to a server. If you need this, [react-dropzone](https://react-dropzone.js.org) suggests [filepond](https://pqina.nl/filepond/) or [uppy.io](https://uppy.io/).
+
 ### Dialog for editing attachments
 
 ```js file="./AttachmentEdit.tsx"

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotFooter/ChatbotFooter.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotFooter/ChatbotFooter.md
@@ -31,6 +31,7 @@ import { BellIcon, CalendarAltIcon, ClipboardIcon, CodeIcon, UploadIcon } from '
 import { useDropzone } from 'react-dropzone';
 
 ### Footnote with popover
+
 A footnote can be placed in a chatbot footer to display any legal disclaimers or information about the chatbot.
 Footnotes can be static text or a button which triggers a popover.
 
@@ -39,13 +40,15 @@ Footnotes can be static text or a button which triggers a popover.
 ```
 
 ### Message bar with speech to text
-By default the message bar enables uploading files. Setting the `hasAttachButton` to `false` will disable that feature.
+
+In Safari and Chrome, you will see a microphone button in the message bar if the prop `hasMicrophoneButton` is passed in. The button will only appear if `'SpeechRecognition'` or `'webkitSpeechRecognition'` are available in `window`. This does not currently work in Firefox. By default the message bar enables uploading files. Setting the `hasAttachButton` to `false` will disable that feature.
 
 ```js file="./ChatbotMessageBar.tsx"
 
 ```
 
 ### Message bar with attach menu appended to attach button
+
 Attachments can also be added to the chatbot via drag and drop. Attachments can also be previewed, edited or deleted. See the [chatbot attachment](/patternfly-ai/chatbot/chatbot-attachment) documentation for more features.
 
 ```js file="./ChatbotMessageBarAttach.tsx"
@@ -55,6 +58,7 @@ Attachments can also be added to the chatbot via drag and drop. Attachments can 
 ### Simple footer with Message bar and footnote
 
 Footers contain the message bar and optional interactive footnote
+
 ```noLive
 <ChatbotFooter>
   <MessageBar ... />

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotFooter/ChatbotMessageBarAttach.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotFooter/ChatbotMessageBarAttach.tsx
@@ -10,7 +10,7 @@ export const ChatbotMessageBarDefaultAttachExample: React.FunctionComponent = ()
   const [userFacingMenuItems, setUserFacingMenuItems] = React.useState<React.ReactNode>([]);
 
   const handleSend = (message) => alert(message);
-  const { open } = useDropzone({
+  const { open, getInputProps } = useDropzone({
     multiple: true,
     // eslint-disable-next-line no-console
     onDropAccepted: () => console.log('fileUploaded')
@@ -124,21 +124,25 @@ export const ChatbotMessageBarDefaultAttachExample: React.FunctionComponent = ()
   ];
 
   return (
-    <MessageBar
-      onSendMessage={handleSend}
-      attachMenuProps={{
-        isAttachMenuOpen: isOpen,
-        setIsAttachMenuOpen: setIsOpen,
-        attachMenuItems: userFacingMenuItems,
-        onAttachMenuSelect: (_ev, value) => {
-          // eslint-disable-next-line no-console
-          console.log('selected', value);
-          setIsOpen(false);
-        },
-        attachMenuInputPlaceholder: 'Search cluster resources...',
-        onAttachMenuInputChange: onTextChange,
-        onAttachMenuToggleClick: onToggleClick
-      }}
-    />
+    <>
+      {/* this is required for react-dropzone to work in Safari and Firefox */}
+      <input {...getInputProps()} />
+      <MessageBar
+        onSendMessage={handleSend}
+        attachMenuProps={{
+          isAttachMenuOpen: isOpen,
+          setIsAttachMenuOpen: setIsOpen,
+          attachMenuItems: userFacingMenuItems,
+          onAttachMenuSelect: (_ev, value) => {
+            // eslint-disable-next-line no-console
+            console.log('selected', value);
+            setIsOpen(false);
+          },
+          attachMenuInputPlaceholder: 'Search cluster resources...',
+          onAttachMenuInputChange: onTextChange,
+          onAttachMenuToggleClick: onToggleClick
+        }}
+      />
+    </>
   );
 };

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachmentMenu.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/demos/ChatbotAttachmentMenu.tsx
@@ -162,7 +162,7 @@ export const BasicDemo: React.FunctionComponent = () => {
   const [showAlert, setShowAlert] = React.useState<boolean>(false);
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
 
-  const { open } = useDropzone({
+  const { open, getInputProps } = useDropzone({
     onDropAccepted: (files: File[]) => {
       setIsLoadingFile(true);
       setIsOpen(false);
@@ -279,6 +279,8 @@ export const BasicDemo: React.FunctionComponent = () => {
   // --------------------------------------------------------------------------
   return (
     <>
+      {/* this is required for react-dropzone to work in Safari and Firefox */}
+      <input {...getInputProps()} />
       <ChatbotToggle
         toolTipLabel="Chatbot"
         isChatbotVisible={chatbotVisible}

--- a/packages/module/src/MessageBar/AttachButton.tsx
+++ b/packages/module/src/MessageBar/AttachButton.tsx
@@ -32,37 +32,42 @@ const AttachButtonBase: React.FunctionComponent<AttachButtonProps> = ({
   innerRef,
   ...props
 }: AttachButtonProps) => {
-  const { open } = useDropzone({
+  const { open, getInputProps } = useDropzone({
     multiple: true,
     onDropAccepted: onAttachAccepted
   });
+
   return (
-    <Tooltip
-      id="pf-chatbot__tooltip--attach"
-      content="Attach"
-      position="top"
-      entryDelay={tooltipProps?.entryDelay || 0}
-      exitDelay={tooltipProps?.exitDelay || 0}
-      distance={tooltipProps?.distance || 8}
-      animationDuration={tooltipProps?.animationDuration || 0}
-      {...tooltipProps}
-    >
-      <Button
-        variant="plain"
-        ref={innerRef}
-        className={`pf-chatbot__button--attach ${className ?? ''}`}
-        aria-describedby="pf-chatbot__tooltip--attach"
-        aria-label={props['aria-label'] || 'Attach Button'}
-        isDisabled={isDisabled}
-        onClick={onClick ?? open}
-        icon={
-          <Icon iconSize="xl" isInline>
-            <PaperclipIcon />
-          </Icon>
-        }
-        {...props}
-      />
-    </Tooltip>
+    <>
+      {/* this is required for react-dropzone to work in Safari and Firefox */}
+      <input {...getInputProps()} />
+      <Tooltip
+        id="pf-chatbot__tooltip--attach"
+        content="Attach"
+        position="top"
+        entryDelay={tooltipProps?.entryDelay || 0}
+        exitDelay={tooltipProps?.exitDelay || 0}
+        distance={tooltipProps?.distance || 8}
+        animationDuration={tooltipProps?.animationDuration || 0}
+        {...tooltipProps}
+      >
+        <Button
+          variant="plain"
+          ref={innerRef}
+          className={`pf-chatbot__button--attach ${className ?? ''}`}
+          aria-describedby="pf-chatbot__tooltip--attach"
+          aria-label={props['aria-label'] || 'Attach Button'}
+          isDisabled={isDisabled}
+          onClick={onClick ?? open}
+          icon={
+            <Icon iconSize="xl" isInline>
+              <PaperclipIcon />
+            </Icon>
+          }
+          {...props}
+        />
+      </Tooltip>
+    </>
   );
 };
 


### PR DESCRIPTION
Left out input required for react-dropzone to work in Safari and Firefox. Consumers should only have to worry about adding this if they incorporate upload into a dropdown, which we give them full control over.

I added a comment where applicable. Also updated a few docs.