### PR TITLE
fix(ChatbotHeaderSelectorDropdown): Try to fix onSelect problem in RHDH

### DIFF
--- a/packages/module/src/ChatbotHeader/ChatbotHeaderOptionsDropdown.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderOptionsDropdown.tsx
@@ -52,7 +52,7 @@ export const ChatbotHeaderOptionsDropdown: React.FunctionComponent<ChatbotHeader
       className={`pf-chatbot__options ${className ?? ''}`}
       isOpen={isOptionsMenuOpen}
       onSelect={(e, value) => {
-        onSelect?.(e, value);
+        onSelect && onSelect(e, value);
         setIsOptionsMenuOpen(false);
       }}
       onOpenChange={(isOpen) => setIsOptionsMenuOpen(isOpen)}

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderSelectorDropdown.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderSelectorDropdown.tsx
@@ -42,7 +42,7 @@ export const ChatbotHeaderSelectorDropdown: React.FunctionComponent<ChatbotHeade
       className={`pf-chatbot__options ${className ?? ''}`}
       isOpen={isOptionsMenuOpen}
       onSelect={(e, value) => {
-        onSelect?.(e, value);
+        onSelect && onSelect(e, value);
         setIsOptionsMenuOpen(false);
       }}
       onOpenChange={(isOpen) => setIsOptionsMenuOpen(isOpen)}


### PR DESCRIPTION
onSelect doesn't trigger appropriately in RHDH Lightspeed and only RHDH Lightspeed. I'm wondering if this isn't the cause - I'm hoping to pull this in there and see if this fixes their problems.