### PR TITLE
fix(Chatbot/FileDropzone): Switch from grid to flex layout

### DIFF
--- a/packages/module/src/Chatbot/Chatbot.scss
+++ b/packages/module/src/Chatbot/Chatbot.scss
@@ -5,9 +5,8 @@
   position: fixed;
   inset-block-end: var(--pf-t--global--spacer--800); // no associated semantic token
   inset-inline-end: var(--pf-t--global--spacer--lg);
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  grid-auto-rows: auto;
+  display: flex;
+  flex-direction: column;
   width: 30rem;
   height: 70vh;
   background-color: var(--pf-t--chatbot--background);

--- a/packages/module/src/FileDropZone/FileDropZone.scss
+++ b/packages/module/src/FileDropZone/FileDropZone.scss
@@ -1,5 +1,6 @@
 .pf-chatbot__dropzone {
   gap: unset; // default PF value causes alignment issues when this is used to wrap other components, notably in the footer
+  flex: 1;
 }
 
 .pf-chatbot__dropzone--invisible {


### PR DESCRIPTION
We had baked in some assumptions with grid to get FileDropZone to work correctly. Unfortunately, this broke when the header was left out. I am switching us to a more flexible flex layout for Chatbot.