### PR TITLE
fix(docs): Switch from path to path-browserify and add id to Message

### DIFF
--- a/config/webpack.cy.config.js
+++ b/config/webpack.cy.config.js
@@ -40,10 +40,7 @@ const JSConfig = {
     ]
   },
   resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
-    fallback: {
-      path: require.resolve('path-browserify')
-    }
+    extensions: ['.tsx', '.ts', '.js']
   },
   output: {
     filename: 'bundle.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "path-browserify": "^1.0.1",
         "react-dropzone": "^14.2.3"
       },
       "devDependencies": {
@@ -23,9 +22,9 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@octokit/rest": "^18.0.0",
-        "@patternfly/documentation-framework": "6.0.0-alpha.109",
-        "@patternfly/patternfly": "6.0.0-prerelease.15",
-        "@patternfly/react-icons": "6.0.0-prerelease.7",
+        "@patternfly/documentation-framework": "^6.0.0-alpha.109",
+        "@patternfly/patternfly": "^6.0.0-prerelease.15",
+        "@patternfly/react-icons": "^6.0.0-prerelease.7",
         "@swc/core": "1.3.96",
         "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^6.4.2",
@@ -27733,6 +27732,7 @@
         "@patternfly/react-icons": "6.0.0-prerelease.7",
         "clsx": "^2.1.0",
         "framer-motion": "^11.3.28",
+        "path-browserify": "^1.0.1",
         "react-jss": "^10.10.0",
         "react-markdown": "^9.0.1",
         "react-syntax-highlighter": "^15.5.0",
@@ -27740,10 +27740,10 @@
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
-        "@patternfly/documentation-framework": "6.0.0-alpha.109",
-        "@patternfly/patternfly": "6.0.0-prerelease.15",
+        "@patternfly/documentation-framework": "^6.0.0-alpha.109",
+        "@patternfly/patternfly": "^6.0.0-prerelease.15",
         "@patternfly/patternfly-a11y": "^4.3.1",
-        "@patternfly/react-table": "6.0.0-prerelease.22",
+        "@patternfly/react-table": "^6.0.0-prerelease.22",
         "@types/dom-speech-recognition": "^0.0.4",
         "@types/react": "^18.2.61",
         "@types/react-dom": "^18.2.19",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "whatwg-fetch": "^3.6.20"
   },
   "dependencies": {
-    "path-browserify": "^1.0.1",
     "react-dropzone": "^14.2.3"
   }
 }

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -40,7 +40,8 @@
     "react-markdown": "^9.0.1",
     "react-syntax-highlighter": "^15.5.0",
     "react-textarea-auto-witdth-height": "^1.0.3",
-    "remark-gfm": "^4.0.0"
+    "remark-gfm": "^4.0.0",
+    "path-browserify": "^1.0.1"
   },
   "peerDependencies": {
     "react": "^17 || ^18",

--- a/packages/module/src/ChatbotContent/ChatbotContent.scss
+++ b/packages/module/src/ChatbotContent/ChatbotContent.scss
@@ -6,6 +6,7 @@
   background-color: var(--pf-t--chatbot--background);
   overflow-y: auto;
   overflow: hidden; // needed in Red Hat Developer Hub workspace
+  flex: 1; // needed in Composer AI
 }
 
 .pf-chatbot--fullscreen {

--- a/packages/module/src/CodeModal/CodeModal.tsx
+++ b/packages/module/src/CodeModal/CodeModal.tsx
@@ -2,7 +2,7 @@
 // Code Modal - Chatbot Modal with Code Editor
 // ============================================================================
 import React from 'react';
-import path from 'path';
+import path from 'path-browserify';
 
 // Import PatternFly components
 import { CodeEditor } from '@patternfly/react-code-editor';

--- a/packages/module/src/FileDetails/FileDetails.tsx
+++ b/packages/module/src/FileDetails/FileDetails.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import { Flex, Stack, StackItem } from '@patternfly/react-core';
-import path from 'path';
+import path from 'path-browserify';
 interface FileDetailsProps {
   /** Name of file, including extension */
   fileName: string;

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -14,6 +14,8 @@ import FileDetailsLabel from '../FileDetailsLabel/FileDetailsLabel';
 import ResponseActions, { ActionProps } from '../ResponseActions/ResponseActions';
 
 export interface MessageProps extends Omit<React.HTMLProps<HTMLDivElement>, 'role'> {
+  /** Unique id for message */
+  id?: string;
   /** Role of the user sending the message */
   role: 'user' | 'bot';
   /** Message content */


### PR DESCRIPTION
I'm still seeing issues in Composer AI where I have to adjust webpack to handle path. I don't think we should assume customers can do this. This should hopefully fix it. I'm also adding an id to messages since it would be helpful in Composer AI.