### PR TITLE
fix(docs): Add prop for aria label

### DIFF
--- a/packages/module/src/AttachMenu/AttachMenu.tsx
+++ b/packages/module/src/AttachMenu/AttachMenu.tsx
@@ -35,6 +35,8 @@ export interface AttachMenuProps extends DropdownProps {
   onSelect?: (event?: React.MouseEvent<Element, MouseEvent>, value?: string | number) => void;
   /** Placeholder for search input */
   searchInputPlaceholder?: string;
+  /** Aria label for search input */
+  searchInputAriaLabel?: string;
   /** Toggle to be rendered */
   toggle: DropdownToggleProps | ((toggleRef: React.RefObject<any>) => React.ReactNode);
 }
@@ -49,6 +51,7 @@ export const AttachMenu: React.FunctionComponent<AttachMenuProps> = ({
   onOpenChangeKeys,
   onSelect,
   searchInputPlaceholder,
+  searchInputAriaLabel = 'Filter menu items',
   toggle,
   ...props
 }: AttachMenuProps) => (
@@ -65,7 +68,7 @@ export const AttachMenu: React.FunctionComponent<AttachMenuProps> = ({
     <MenuSearch>
       <MenuSearchInput>
         <SearchInput
-          aria-label="Filter menu items"
+          aria-label={searchInputAriaLabel}
           onChange={(_event, value) => handleTextInputChange(value)}
           placeholder={searchInputPlaceholder}
         />

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
@@ -64,6 +64,8 @@ export interface ChatbotConversationHistoryNavProps extends DrawerProps {
   drawerContent?: React.ReactNode;
   /** Placeholder for search input */
   searchInputPlaceholder?: string;
+  /** Aria label for search input */
+  searchInputAriaLabel?: string;
   /** A callback for when the input value changes. Omit to hide input field */
   handleTextInputChange?: (value: string) => void;
   /** Display mode of chatbot */
@@ -79,7 +81,8 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
   newChatButtonText = 'New chat',
   drawerContent,
   onNewChat,
-  searchInputPlaceholder,
+  searchInputPlaceholder = 'Search...',
+  searchInputAriaLabel = 'Filter menu items',
   handleTextInputChange,
   displayMode,
   ...props
@@ -163,9 +166,9 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
       {handleTextInputChange && (
         <div className="pf-chatbot__input">
           <SearchInput
-            aria-label="Filter menu items"
+            aria-label={searchInputAriaLabel}
             onChange={(_event, value) => handleTextInputChange(value)}
-            placeholder={searchInputPlaceholder ?? 'Search...'}
+            placeholder={searchInputPlaceholder}
           />
         </div>
       )}

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderMenu.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderMenu.tsx
@@ -10,12 +10,15 @@ export interface ChatbotHeaderMenuProps {
   className?: string;
   /** Props spread to the PF Tooltip component wrapping the display mode dropdown */
   tooltipProps?: TooltipProps;
+  /** Aria label for menu */
+  menuAriaLabel?: string;
 }
 
 export const ChatbotHeaderMenu: React.FunctionComponent<ChatbotHeaderMenuProps> = ({
   className,
   onMenuToggle,
-  tooltipProps
+  tooltipProps,
+  menuAriaLabel = 'Toggle menu'
 }: ChatbotHeaderMenuProps) => (
   <div className={`pf-chatbot__menu ${className}`}>
     <Tooltip content="Menu" position="bottom" {...tooltipProps}>
@@ -24,7 +27,7 @@ export const ChatbotHeaderMenu: React.FunctionComponent<ChatbotHeaderMenuProps> 
         variant="plain"
         aria-describedby="pf-chatbot__tooltip--toggle-menu"
         onClick={onMenuToggle}
-        aria-label="Toggle menu"
+        aria-label={menuAriaLabel}
         icon={
           <Icon size="xl" isInline>
             <BarsIcon />

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderOptionsDropdown.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderOptionsDropdown.tsx
@@ -18,6 +18,8 @@ export interface ChatbotHeaderOptionsDropdownProps extends Omit<DropdownProps, '
   className?: string;
   /** Props spread to the PF Tooltip component wrapping the display mode dropdown */
   tooltipProps?: TooltipProps;
+  /** Aria label for menu toggle */
+  menuToggleAriaLabel?: string;
 }
 
 export const ChatbotHeaderOptionsDropdown: React.FunctionComponent<ChatbotHeaderOptionsDropdownProps> = ({
@@ -25,6 +27,7 @@ export const ChatbotHeaderOptionsDropdown: React.FunctionComponent<ChatbotHeader
   children,
   onSelect,
   tooltipProps,
+  menuToggleAriaLabel = 'Chatbot options',
   ...props
 }: ChatbotHeaderOptionsDropdownProps) => {
   const [isOptionsMenuOpen, setIsOptionsMenuOpen] = React.useState(false);
@@ -34,7 +37,7 @@ export const ChatbotHeaderOptionsDropdown: React.FunctionComponent<ChatbotHeader
       <MenuToggle
         className="pf-chatbot__button--toggle-options"
         variant="plain"
-        aria-label="Chatbot options"
+        aria-label={menuToggleAriaLabel}
         ref={toggleRef}
         icon={
           <Icon iconSize="xl" isInline>

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderSelectorDropdown.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderSelectorDropdown.tsx
@@ -11,6 +11,8 @@ export interface ChatbotHeaderSelectorDropdownProps extends Omit<DropdownProps, 
   className?: string;
   /** Props spread to the PF Tooltip component wrapping the display mode dropdown */
   tooltipProps?: TooltipProps;
+  /** Aria label for menu toggle */
+  menuToggleAriaLabel?: string;
 }
 
 export const ChatbotHeaderSelectorDropdown: React.FunctionComponent<ChatbotHeaderSelectorDropdownProps> = ({
@@ -19,6 +21,7 @@ export const ChatbotHeaderSelectorDropdown: React.FunctionComponent<ChatbotHeade
   children,
   onSelect,
   tooltipProps,
+  menuToggleAriaLabel = 'Chatbot selector',
   ...props
 }: ChatbotHeaderSelectorDropdownProps) => {
   const [isOptionsMenuOpen, setIsOptionsMenuOpen] = React.useState(false);
@@ -27,7 +30,7 @@ export const ChatbotHeaderSelectorDropdown: React.FunctionComponent<ChatbotHeade
     <Tooltip className="pf-chatbot__tooltip" content="Chatbot selector" position="bottom" {...tooltipProps}>
       <MenuToggle
         variant="secondary"
-        aria-label="Chatbot selector"
+        aria-label={menuToggleAriaLabel}
         ref={toggleRef}
         isExpanded={isOptionsMenuOpen}
         onClick={() => setIsOptionsMenuOpen(!isOptionsMenuOpen)}


### PR DESCRIPTION
Allow user to customize user-composable components for i18n, etc.

I'm leaving the ones in the old code that it looks like we didn't write, as well as the CodeMessage, since the user can't touch that.