### PR TITLE
fix(JumpButton): Make styles important for now

### DIFF
--- a/packages/module/src/MessageBox/JumpButton.scss
+++ b/packages/module/src/MessageBox/JumpButton.scss
@@ -1,50 +1,51 @@
 // ============================================================================
 // Chatbot Jump Button
 // ============================================================================
+// importants are temporary until we can find a workaround for the way Backstage is pulling in style sheets
 .pf-chatbot__jump {
-  position: absolute;
-  inset-inline-start: 50%;
-  width: 3rem;
-  height: 3rem;
-  padding: var(--pf-t--global--spacer--md);
-  border-radius: var(--pf-t--global--border--radius--pill);
+  position: absolute !important;
+  inset-inline-start: 50% !important;
+  width: 3rem !important;
+  height: 3rem !important;
+  padding: var(--pf-t--global--spacer--md) !important;
+  border-radius: var(--pf-t--global--border--radius--pill) !important;
 
-  background-color: var(--pf-t--chatbot--jump--background);
-  border: 1px solid var(--pf-t--chatbot--border);
+  background-color: var(--pf-t--chatbot--jump--background) !important;
+  border: 1px solid var(--pf-t--chatbot--border) !important;
   box-shadow: var(--pf-t--global--box-shadow--sm);
-  color: var(--pf-t--chatbot--icon--fill);
-  transform: translate3d(-50%, 0, 0);
+  color: var(--pf-t--chatbot--icon--fill) !important;
+  transform: translate3d(-50%, 0, 0) !important;
   transition:
     background-color var(--pf-t--chatbot--timing-function) var(--pf-t--global--motion--duration--sm),
     box-shadow var(--pf-t--chatbot--timing-function) var(--pf-t--global--motion--duration--sm),
     transform var(--pf-t--chatbot--timing-function) var(--pf-t--global--motion--duration--md),
-    opacity var(--pf-t--chatbot--timing-function) var(--pf-t--global--motion--duration--md);
-  z-index: var(--pf-t--global--z-index--md);
+    opacity var(--pf-t--chatbot--timing-function) var(--pf-t--global--motion--duration--md) !important;
+  z-index: var(--pf-t--global--z-index--md) !important;
 
   &:hover,
   &:focus {
-    background-color: var(--pf-t--chatbot--jump--background--hover);
-    box-shadow: var(--pf-t--global--box-shadow--md);
-    color: var(--pf-t--chatbot--icon--fill--hover);
+    background-color: var(--pf-t--chatbot--jump--background--hover) !important;
+    box-shadow: var(--pf-t--global--box-shadow--md) !important;
+    color: var(--pf-t--chatbot--icon--fill--hover) !important;
   }
 
   &--top {
-    inset-block-start: var(--pf-t--global--spacer--md);
+    inset-block-start: var(--pf-t--global--spacer--md) !important;
 
     &--hidden {
-      transform: translate3d(-50%, -8px, 0);
-      opacity: 0;
-      pointer-events: none;
+      transform: translate3d(-50%, -8px, 0) !important;
+      opacity: 0 !important;
+      pointer-events: none !important;
     }
   }
 
   &--bottom {
-    inset-block-end: var(--pf-t--global--spacer--md);
+    inset-block-end: var(--pf-t--global--spacer--md) !important;
 
     &--hidden {
-      transform: translate3d(-50%, 8px, 0);
-      opacity: 0;
-      pointer-events: none;
+      transform: translate3d(-50%, 8px, 0) !important;
+      opacity: 0 !important;
+      pointer-events: none !important;
     }
   }
 }


### PR DESCRIPTION
Backstage is pulling in button.css a million times before JumpButton and it overrides a lot. This is temporary so we can get it to behave correctly. We'll go back and investigate to see if there is a way to handle this better in Backstage after the release.