### PR TITLE
fix(AttachMenu): Allow tabbing into input

### DIFF
--- a/packages/module/src/AttachMenu/AttachMenu.tsx
+++ b/packages/module/src/AttachMenu/AttachMenu.tsx
@@ -59,7 +59,7 @@ export const AttachMenu: React.FunctionComponent<AttachMenuProps> = ({
     className={`pf-chatbot__menu ${className ?? ''}`}
     isOpen={isOpen}
     onOpenChange={(isOpen) => onOpenChange(isOpen)}
-    onOpenChangeKeys={onOpenChangeKeys}
+    onOpenChangeKeys={onOpenChangeKeys ?? ['Esc']}
     toggle={toggle}
     popperProps={popperProps}
     onSelect={onSelect}


### PR DESCRIPTION
Needed to change onOpenChangeKeys so it excluded tab - Eric absolutely called it.