### PR TITLE
feat(FileDetails): Add additional file types

### DIFF
--- a/packages/module/src/FileDetails/FileDetails.tsx
+++ b/packages/module/src/FileDetails/FileDetails.tsx
@@ -921,7 +921,15 @@ export const extensionToLanguage = {
   'rst.txt': 'reStructuredText',
   wisp: 'wisp',
   prg: 'xBase',
-  prw: 'xBase'
+  prw: 'xBase',
+  // manually added for Composer AI
+  doc: 'Document',
+  docx: 'Document',
+  odt: 'Document',
+  ppt: 'Presentation',
+  pptx: 'Presentation',
+  odp: 'Presentation',
+  pdf: 'PDF'
 };
 
 export const FileDetails = ({ fileName }: PropsWithChildren<FileDetailsProps>) => {


### PR DESCRIPTION
Need to add additional extensions to map for use in Composer AI. React-dropzone is filetype agnostic, so it shouldn't care, but this will allow us to display labels with intelligent file types.