### PR TITLE
fix(FileDetails/FileDetailsLabel): Adjust chip width

### DIFF
--- a/packages/module/src/FileDetails/FileDetails.tsx
+++ b/packages/module/src/FileDetails/FileDetails.tsx
@@ -1,11 +1,15 @@
 import React, { PropsWithChildren } from 'react';
-import { Flex, Stack, StackItem } from '@patternfly/react-core';
+import { Flex, Stack, StackItem, Truncate } from '@patternfly/react-core';
 import path from 'path-browserify';
 interface FileDetailsProps {
+  /** Class name applied to container */
+  className?: string;
   /** Name of file, including extension */
   fileName: string;
   /** Custom test id for the component-generated language */
   languageTestId?: string;
+  /** Class name applied to file name */
+  fileNameClassName?: string;
 }
 
 // source https://gist.github.com/ppisarczyk/43962d06686722d26d176fad46879d41
@@ -934,10 +938,15 @@ export const extensionToLanguage = {
   pdf: 'PDF'
 };
 
-export const FileDetails = ({ fileName, languageTestId }: PropsWithChildren<FileDetailsProps>) => {
+export const FileDetails = ({
+  className,
+  fileName,
+  fileNameClassName,
+  languageTestId
+}: PropsWithChildren<FileDetailsProps>) => {
   const language = extensionToLanguage[path.extname(fileName).slice(1)]?.toUpperCase();
   return (
-    <Flex gap={{ default: 'gapSm' }}>
+    <Flex className={`pf-chatbot__file-details ${className}`} gap={{ default: 'gapSm' }}>
       <Flex
         className="pf-chatbot__code-icon"
         justifyContent={{ default: 'justifyContentCenter' }}
@@ -964,7 +973,9 @@ export const FileDetails = ({ fileName, languageTestId }: PropsWithChildren<File
       </Flex>
       <Stack>
         <StackItem>
-          <span className="pf-chatbot__code-fileName">{path.parse(fileName).name}</span>
+          <span className="pf-chatbot__code-fileName">
+            <Truncate className={fileNameClassName} content={path.parse(fileName).name} />
+          </span>
         </StackItem>
         {language && (
           <StackItem data-testid={languageTestId} className="pf-chatbot__code-language">

--- a/packages/module/src/FileDetails/__snapshots__/FileDetails.test.tsx.snap
+++ b/packages/module/src/FileDetails/__snapshots__/FileDetails.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FileDetails should render file details 1`] = `
 <div>
   <div
-    class="pf-v6-l-flex pf-m-gap-sm"
+    class="pf-v6-l-flex pf-m-gap-sm pf-chatbot__file-details undefined"
   >
     <div
       class="pf-v6-l-flex pf-m-align-items-center pf-m-align-self-center pf-m-justify-content-center pf-chatbot__code-icon"
@@ -48,7 +48,19 @@ exports[`FileDetails should render file details 1`] = `
         <span
           class="pf-chatbot__code-fileName"
         >
-          test
+          <div
+            style="display: contents;"
+          >
+            <span
+              class="pf-v6-c-truncate"
+            >
+              <span
+                class="pf-v6-c-truncate__start"
+              >
+                test
+              </span>
+            </span>
+          </div>
         </span>
       </div>
       <div

--- a/packages/module/src/FileDetailsLabel/FileDetailsLabel.scss
+++ b/packages/module/src/FileDetailsLabel/FileDetailsLabel.scss
@@ -1,8 +1,25 @@
+.pf-chatbot__file-label-contents {
+  display: flex;
+  gap: var(--pf-t--global--spacer--md);
+  justify-content: center;
+  align-items: center;
+}
+
 .pf-chatbot__file-label {
   padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md) var(--pf-t--global--spacer--sm)
     var(--pf-t--global--spacer--md);
   gap: var(--pf-t--global--spacer--sm);
   --pf-v6-c-label--m-clickable--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
+  --pf-v6-c-label--MaxWidth: 12rem;
+  .pf-v6-c-truncate {
+    max-width: 9ch;
+  }
+
+  .pf-v6-c-label__content,
+  .pf-v6-c-label__text {
+    --pf-v6-c-label__content--MaxWidth: 100%;
+    --pf-v6-c-label__text--MaxWidth: 100%;
+  }
 }
 
 .pf-v6-c-label.pf-chatbot__file-label {
@@ -32,5 +49,18 @@
 
   .pf-chatbot__code-icon {
     color: var(--pf-t--global--icon--color--status--custom--hover);
+  }
+}
+
+.pf-chatbot__file-label-loading {
+  .pf-v6-c-truncate {
+    max-width: 6ch;
+  }
+}
+
+.pf-chatbot--embedded,
+.pf-chatbot--fullscreen {
+  .pf-chatbot__file-label {
+    --pf-v6-c-label--MaxWidth: 14rem;
   }
 }

--- a/packages/module/src/FileDetailsLabel/FileDetailsLabel.tsx
+++ b/packages/module/src/FileDetailsLabel/FileDetailsLabel.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-import { Button, Flex, FlexItem, Label } from '@patternfly/react-core';
+import { Button, Label } from '@patternfly/react-core';
 import FileDetails from '../FileDetails';
 import { Spinner } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
@@ -43,22 +43,15 @@ export const FileDetailsLabel = ({
       />
     }
     onClick={onClick}
-    textMaxWidth="370px"
   >
-    <Flex
-      justifyContent={{ default: 'justifyContentCenter' }}
-      alignItems={{ default: 'alignItemsCenter' }}
-      gap={{ default: 'gapMd' }}
-    >
-      <FlexItem>
-        <FileDetails fileName={fileName} languageTestId={languageTestId} />
-      </FlexItem>
-      {isLoading && (
-        <FlexItem>
-          <Spinner data-testid={spinnerTestId} size="sm" />
-        </FlexItem>
-      )}
-    </Flex>
+    <div className="pf-chatbot__file-label-contents">
+      <FileDetails
+        className={isLoading ? 'pf-chatbot__file-label-loading' : undefined}
+        fileName={fileName}
+        languageTestId={languageTestId}
+      />
+      {isLoading && <Spinner data-testid={spinnerTestId} size="sm" />}
+    </div>
   </Label>
 );
 

--- a/packages/module/src/FileDetailsLabel/__snapshots__/FileDetailsLabel.test.tsx.snap
+++ b/packages/module/src/FileDetailsLabel/__snapshots__/FileDetailsLabel.test.tsx.snap
@@ -10,68 +10,75 @@ exports[`FileDetailsLabel should render file details label 1`] = `
     >
       <span
         class="pf-v6-c-label__text"
-        style="--pf-v6-c-label__text--MaxWidth: 370px;"
       >
         <div
-          class="pf-v6-l-flex pf-m-align-items-center pf-m-justify-content-center pf-m-gap-md"
+          class="pf-chatbot__file-label-contents"
         >
           <div
-            class=""
+            class="pf-v6-l-flex pf-m-gap-sm pf-chatbot__file-details undefined"
           >
             <div
-              class="pf-v6-l-flex pf-m-gap-sm"
+              class="pf-v6-l-flex pf-m-align-items-center pf-m-align-self-center pf-m-justify-content-center pf-chatbot__code-icon"
             >
-              <div
-                class="pf-v6-l-flex pf-m-align-items-center pf-m-align-self-center pf-m-justify-content-center pf-chatbot__code-icon"
+              <svg
+                fill="currentColor"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
+                <path
+                  d="M0 4C0 1.79086 1.79086 0 4 0H20C22.2091 0 24 1.79086 24 4V20C24 22.2091 22.2091 24 20 24H4C1.79086 24 0 22.2091 0 20V4Z"
                   fill="currentColor"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
+                />
+                <g
+                  clip-path="url(#clip0_3280_27505)"
                 >
                   <path
-                    d="M0 4C0 1.79086 1.79086 0 4 0H20C22.2091 0 24 1.79086 24 4V20C24 22.2091 22.2091 24 20 24H4C1.79086 24 0 22.2091 0 20V4Z"
-                    fill="currentColor"
+                    d="M13.8204 5.63002C13.3954 5.50752 12.9529 5.75502 12.8304 6.18002L9.63035 17.38C9.50785 17.805 9.75535 18.2475 10.1804 18.37C10.6054 18.4925 11.0479 18.245 11.1704 17.82L14.3704 6.62002C14.4929 6.19502 14.2454 5.75252 13.8204 5.63002ZM15.8354 8.63252C15.5229 8.94502 15.5229 9.45252 15.8354 9.76502L18.0679 12L15.8329 14.235C15.5204 14.5475 15.5204 15.055 15.8329 15.3675C16.1454 15.68 16.6529 15.68 16.9654 15.3675L19.7654 12.5675C20.0779 12.255 20.0779 11.7475 19.7654 11.435L16.9654 8.63502C16.6529 8.32252 16.1454 8.32252 15.8329 8.63502L15.8354 8.63252ZM8.16785 8.63252C7.85535 8.32002 7.34785 8.32002 7.03535 8.63252L4.23535 11.4325C3.92285 11.745 3.92285 12.2525 4.23535 12.565L7.03535 15.365C7.34785 15.6775 7.85535 15.6775 8.16785 15.365C8.48035 15.0525 8.48035 14.545 8.16785 14.2325L5.93285 12L8.16785 9.76502C8.48035 9.45252 8.48035 8.94502 8.16785 8.63252Z"
+                    fill="white"
                   />
-                  <g
-                    clip-path="url(#clip0_3280_27505)"
-                  >
-                    <path
-                      d="M13.8204 5.63002C13.3954 5.50752 12.9529 5.75502 12.8304 6.18002L9.63035 17.38C9.50785 17.805 9.75535 18.2475 10.1804 18.37C10.6054 18.4925 11.0479 18.245 11.1704 17.82L14.3704 6.62002C14.4929 6.19502 14.2454 5.75252 13.8204 5.63002ZM15.8354 8.63252C15.5229 8.94502 15.5229 9.45252 15.8354 9.76502L18.0679 12L15.8329 14.235C15.5204 14.5475 15.5204 15.055 15.8329 15.3675C16.1454 15.68 16.6529 15.68 16.9654 15.3675L19.7654 12.5675C20.0779 12.255 20.0779 11.7475 19.7654 11.435L16.9654 8.63502C16.6529 8.32252 16.1454 8.32252 15.8329 8.63502L15.8354 8.63252ZM8.16785 8.63252C7.85535 8.32002 7.34785 8.32002 7.03535 8.63252L4.23535 11.4325C3.92285 11.745 3.92285 12.2525 4.23535 12.565L7.03535 15.365C7.34785 15.6775 7.85535 15.6775 8.16785 15.365C8.48035 15.0525 8.48035 14.545 8.16785 14.2325L5.93285 12L8.16785 9.76502C8.48035 9.45252 8.48035 8.94502 8.16785 8.63252Z"
+                </g>
+                <defs>
+                  <clippath>
+                    <rect
                       fill="white"
+                      height="12.8"
+                      transform="translate(4 5.60001)"
+                      width="16"
                     />
-                  </g>
-                  <defs>
-                    <clippath>
-                      <rect
-                        fill="white"
-                        height="12.8"
-                        transform="translate(4 5.60001)"
-                        width="16"
-                      />
-                    </clippath>
-                  </defs>
-                </svg>
+                  </clippath>
+                </defs>
+              </svg>
+            </div>
+            <div
+              class="pf-v6-l-stack"
+            >
+              <div
+                class="pf-v6-l-stack__item"
+              >
+                <span
+                  class="pf-chatbot__code-fileName"
+                >
+                  <div
+                    style="display: contents;"
+                  >
+                    <span
+                      class="pf-v6-c-truncate"
+                    >
+                      <span
+                        class="pf-v6-c-truncate__start"
+                      >
+                        test
+                      </span>
+                    </span>
+                  </div>
+                </span>
               </div>
               <div
-                class="pf-v6-l-stack"
+                class="pf-v6-l-stack__item pf-chatbot__code-language"
               >
-                <div
-                  class="pf-v6-l-stack__item"
-                >
-                  <span
-                    class="pf-chatbot__code-fileName"
-                  >
-                    test
-                  </span>
-                </div>
-                <div
-                  class="pf-v6-l-stack__item pf-chatbot__code-language"
-                >
-                  TEXT
-                </div>
+                TEXT
               </div>
             </div>
           </div>


### PR DESCRIPTION
We were relying on the default PatternFly label behavior for long titles. Mark raised a concern that this will cause problems in the future when we enable multiple file uploads. This PR adjusts the chip so it has text truncation and a max width. The loading state should also look a little more consistent when titles are long.

<img width="473" alt="Screenshot 2024-10-22 at 4 01 04 PM" src="https://github.com/user-attachments/assets/8cfbc2d0-488a-4cad-afcf-a847e67b8a84">

Modals use the same text treatment, meaning that they will have truncation.

Short title:
<img width="502" alt="Screenshot 2024-10-22 at 4 06 20 PM" src="https://github.com/user-attachments/assets/91e90b31-d4fb-4410-90f0-a787036a5d58">

Long title:
<img width="484" alt="Screenshot 2024-10-22 at 3 57 35 PM" src="https://github.com/user-attachments/assets/22df9384-f22e-41d3-8543-2e6975d95db2">
