### PR TITLE
fix(ChatbotHeader/Message): Disable pointer events

### DIFF
--- a/packages/module/src/ChatbotHeader/ChatbotHeader.scss
+++ b/packages/module/src/ChatbotHeader/ChatbotHeader.scss
@@ -16,6 +16,10 @@
   .pf-chatbot__header-main {
     display: flex;
     gap: var(--pf-t--global--spacer--sm);
+
+    img {
+      pointer-events: none; // prevent dragging on any brand images - interferes with FileDropZone
+    }
   }
 
   // Title -or- Brand

--- a/packages/module/src/Message/Message.scss
+++ b/packages/module/src/Message/Message.scss
@@ -25,6 +25,7 @@
     position: sticky;
     top: var(--pf-t--global--spacer--md);
     object-fit: cover;
+    pointer-events: none; // prevent dragging - interferes with FileDropZone
   }
 
   // Contents


### PR DESCRIPTION
Before these were added, it was possible to drag the avatars or header images into the drag and drop field, which is a bug. These CSS classes prevent this from happening.