### PR TITLE
fix(CodeModal): Add scope to backdrop CSS

### DIFF
--- a/packages/module/src/CodeModal/CodeModal.scss
+++ b/packages/module/src/CodeModal/CodeModal.scss
@@ -1,3 +1,7 @@
+.pf-chatbot__code-modal-backdrop {
+  position: static;
+}
+
 .pf-chatbot__code-modal {
   --pf-v6-c-modal-box--BorderRadius: var(--pf-t--global--border--radius--medium);
   position: fixed;

--- a/packages/module/src/CodeModal/CodeModal.tsx
+++ b/packages/module/src/CodeModal/CodeModal.tsx
@@ -105,6 +105,7 @@ export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
       aria-labelledby="code-modal-title"
       aria-describedby="code-modal"
       className={`pf-chatbot__code-modal pf-chatbot__code-modal--${displayMode}`}
+      backdropClassName="pf-chatbot__code-modal-backdrop"
     >
       <ModalHeader title={title} labelId="code-modal-title" />
       <ModalBody id="code-modal-body">

--- a/packages/module/src/main.scss
+++ b/packages/module/src/main.scss
@@ -88,11 +88,3 @@
   left: 0 !important;
   right: auto !important;
 }
-
-/* This is for the Code Modals, so they act like they're part of the
-/* chatbot. The PF modal doesn't allow us to change the position in
-/* a more targeted way, because you can only add classes onto the
-/* dialog itself.  */
-.pf-v6-c-backdrop {
-  position: static;
-}


### PR DESCRIPTION
Backdrop CSS change was not scoped, leading to leaking in PatternFly.org. This should scope it appopriately.