### PR TITLE
feat(ResponseActions): Allow for custom response actions

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/ChatbotMessage.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/ChatbotMessage.md
@@ -23,6 +23,9 @@ import PreviewAttachment from '@patternfly/virtual-assistant/dist/dynamic/Previe
 import AttachmentEdit from '@patternfly/virtual-assistant/dist/dynamic/AttachmentEdit';
 import SourcesCard from '@patternfly/virtual-assistant/dist/dynamic/SourcesCard';
 import { RobotIcon } from '@patternfly/react-icons/dist/esm/icons/robot-icon';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import RedoIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';
 import patternflyAvatar from './patternfly_avatar.jpg';
 import userAvatar from './user_avatar.jpg';
 
@@ -73,6 +76,14 @@ You can add actions to a message, to allow users to interact with the message co
 **Note:** The logic for the actions is not built into the component and must be implemented by the consuming application.
 
 ```js file="./MessageWithResponseActions.tsx"
+
+```
+
+### Custom messages actions
+
+You can add custom actions by passing an `actions` object with a key other than positive, negative, copy, share, or listen. This object can contain the following customizations: `ariaLabel`, `onClick`, `className`, `isDisabled`, `tooltipContent`, `tooltipProps`, and `icon`.
+
+```js file="./MessageWithCustomResponseActions.tsx"
 
 ```
 

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/ChatbotMessage.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/ChatbotMessage.md
@@ -65,7 +65,7 @@ If a `displayMode` is not passed to `<PreviewAttachment>` or `<AttachmentEdit>`,
 
 ```
 
-### Messages actions
+### Message actions
 
 You can add actions to a message, to allow users to interact with the message content. These actions can include:
 
@@ -79,9 +79,9 @@ You can add actions to a message, to allow users to interact with the message co
 
 ```
 
-### Custom messages actions
+### Custom message actions
 
-You can add custom actions by passing an `actions` object with a key other than positive, negative, copy, share, or listen. This object can contain the following customizations: `ariaLabel`, `onClick`, `className`, `isDisabled`, `tooltipContent`, `tooltipProps`, and `icon`.
+Beyond the standard message actions (positive, negative, copy, share, or listen), you can add custom actions to a bot message by passing an `actions` object to the `<Message>` component. This object can contain the following customizations: `ariaLabel`, `onClick`, `className`, `isDisabled`, `tooltipContent`, `tooltipProps`, and `icon`.
 
 ```js file="./MessageWithCustomResponseActions.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/MessageWithCustomResponseActions.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/MessageWithCustomResponseActions.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import Message from '@patternfly/virtual-assistant/dist/dynamic/Message';
+import patternflyAvatar from './patternfly_avatar.jpg';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import RedoIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';
+
+export const CustomActionExample: React.FunctionComponent = () => (
+  <Message
+    name="Bot"
+    role="bot"
+    avatar={patternflyAvatar}
+    content="Example with custom actions"
+    actions={{
+      regenerate: {
+        ariaLabel: 'Regenerate',
+        // eslint-disable-next-line no-console
+        onClick: () => console.log('Clicked regenerate'),
+        tooltipContent: 'Regenerate',
+        icon: <RedoIcon />
+      },
+      download: {
+        ariaLabel: 'Download',
+        // eslint-disable-next-line no-console
+        onClick: () => console.log('Clicked download'),
+        tooltipContent: 'Download',
+        icon: <DownloadIcon />
+      },
+      info: {
+        ariaLabel: 'Info',
+        // eslint-disable-next-line no-console
+        onClick: () => console.log('Clicked info'),
+        tooltipContent: 'Info',
+        icon: <InfoCircleIcon />
+      }
+    }}
+  />
+);

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/MessageWithResponseActions.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/MessageWithResponseActions.tsx
@@ -3,13 +3,12 @@ import React from 'react';
 import Message from '@patternfly/virtual-assistant/dist/dynamic/Message';
 import patternflyAvatar from './patternfly_avatar.jpg';
 
-export const AttachmentMenuExample: React.FunctionComponent = () => (
+export const ResponseActionExample: React.FunctionComponent = () => (
   <Message
     name="Bot"
     role="bot"
     avatar={patternflyAvatar}
-    content="Example content with updated timestamp text"
-    timestamp="1 hour ago"
+    content="Example with all prebuilt actions"
     actions={{
       // eslint-disable-next-line no-console
       positive: { onClick: () => console.log('Good response') },

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -39,11 +39,7 @@ export interface MessageProps extends Omit<React.HTMLProps<HTMLDivElement>, 'rol
   onAttachmentClose?: (attachmentId: string) => void;
   /** Props for message actions, such as feedback (positive or negative), copy button, share, and listen */
   actions?: {
-    positive?: ActionProps;
-    negative?: ActionProps;
-    copy?: ActionProps;
-    share?: ActionProps;
-    listen?: ActionProps;
+    [key: string]: ActionProps;
   };
   sources?: SourcesCardProps;
 }

--- a/packages/module/src/ResponseActions/ResponseActions.tsx
+++ b/packages/module/src/ResponseActions/ResponseActions.tsx
@@ -22,11 +22,13 @@ export interface ActionProps {
   tooltipContent?: string;
   /** Props to control the PF Tooltip component */
   tooltipProps?: TooltipProps;
+  /** Icon for custom response action */
+  icon?: React.ReactNode;
 }
 
 export interface ResponseActionProps {
   /** Props for message actions, such as feedback (positive or negative), copy button, share, and listen */
-  actions: {
+  actions: Record<string, ActionProps | undefined> & {
     positive?: ActionProps;
     negative?: ActionProps;
     copy?: ActionProps;
@@ -36,7 +38,7 @@ export interface ResponseActionProps {
 }
 
 export const ResponseActions: React.FunctionComponent<ResponseActionProps> = ({ actions }) => {
-  const { positive, negative, copy, share, listen } = actions;
+  const { positive, negative, copy, share, listen, ...additionalActions } = actions;
   return (
     <div className="pf-chatbot__response-actions">
       {positive && (
@@ -94,6 +96,18 @@ export const ResponseActions: React.FunctionComponent<ResponseActionProps> = ({ 
           icon={<VolumeUpIcon />}
         ></ResponseActionButton>
       )}
+      {Object.keys(additionalActions).map((action) => (
+        <ResponseActionButton
+          key={action}
+          ariaLabel={additionalActions[action]?.ariaLabel}
+          onClick={additionalActions[action]?.onClick}
+          className={additionalActions[action]?.className}
+          isDisabled={additionalActions[action]?.isDisabled}
+          tooltipContent={additionalActions[action]?.tooltipContent}
+          tooltipProps={additionalActions[action]?.tooltipProps}
+          icon={additionalActions[action]?.icon}
+        />
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
Two products have asked for response actions we don't have - this should enable consumers to add whatever they need.

Section I added: https://virtual-assistant-pr-virtual-assistant-285.surge.sh/patternfly-ai/chatbot/chatbot-messages#custom-messages-actions