### PR TITLE
fix(TextMessage): Allow for more complex list output

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/BotMessage.tsx
@@ -57,7 +57,7 @@ export default MessageLoading;
 
 2. **Using a \`knife\`:**
 
-     Acquire 1 tablespoon of room temperature \`butter\`. Use \`knife\` to spread butter on \`toast\`. Bon appetit!
+     Acquire 1 tablespoon of room temperature \`butter\`. Use \`knife\` to spread butter on \`toast\`. Bon appétit!
  `;
 
   return (

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/BotMessage.tsx
@@ -48,6 +48,18 @@ export default MessageLoading;
   * Item 2
   * Item 3`;
 
+  const moreComplexList = `You may be wondering whether you can display more complex lists with formatting. In response to your question, I will explain how to butter toast.
+
+1. **Using a \`toaster\`:**
+
+   - Place \`bread\` in a \`toaster\`
+   - Once \`bread\` is lightly browned, remove from \`toaster\`
+
+2. **Using a \`knife\`:**
+
+     Acquire 1 tablespoon of room temperature \`butter\`. Use \`knife\` to spread butter on \`toast\`. Bon appetit!
+ `;
+
   return (
     <>
       <Message
@@ -60,6 +72,7 @@ export default MessageLoading;
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content={markdown} />
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content={orderedList} />
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content={unorderedList} />
+      <Message name="Bot" role="bot" avatar={patternflyAvatar} content={moreComplexList} />
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content="Example content" isLoading />
     </>
   );

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/ChatbotMessage/BotMessage.tsx
@@ -48,7 +48,7 @@ export default MessageLoading;
   * Item 2
   * Item 3`;
 
-  const moreComplexList = `You may be wondering whether you can display more complex lists with formatting. In response to your question, I will explain how to butter toast.
+  const moreComplexList = `You may be wondering whether you can display more complex lists with formatting. In response to your question, I will explain how to spread butter on toast.
 
 1. **Using a \`toaster\`:**
 

--- a/packages/module/src/Message/TextMessage/TextMessage.scss
+++ b/packages/module/src/Message/TextMessage/TextMessage.scss
@@ -2,6 +2,14 @@
 // Chatbot Main - Message - Content - Text
 // ============================================================================
 
+.pf-chatbot__message-and-actions {
+  blockquote {
+    .pf-chatbot__message-text {
+      display: inline-block;
+    }
+  }
+}
+
 // Need to inline shorter text
 .pf-chatbot__message-text {
   width: fit-content;
@@ -14,10 +22,6 @@
   p,
   a {
     --pf-v6-c-content--FontSize: var(--pf-t--chatbot--font-size);
-  }
-
-  p {
-    display: inline-block;
   }
 
   code {

--- a/packages/module/src/Message/TextMessage/TextMessage.tsx
+++ b/packages/module/src/Message/TextMessage/TextMessage.tsx
@@ -7,11 +7,11 @@ import { ExtraProps } from 'react-markdown';
 import { Content, ContentVariants } from '@patternfly/react-core';
 
 const TextMessage = ({ children, ...props }: JSX.IntrinsicElements['p'] & ExtraProps) => (
-  <div className="pf-chatbot__message-text">
+  <span className="pf-chatbot__message-text">
     <Content component={ContentVariants.p} {...props}>
       {children}
     </Content>
-  </div>
+  </span>
 );
 
 export default TextMessage;


### PR DESCRIPTION
In Composer AI, we were seeing bad list rendering when lists contained complex formatting. React-markdown seems to categorize the complex formatting as p tags. Since they all had an inline-block on them, this caused rendering issues when the p tag was in an li. This should fix it. I also brought in a silly, more complex example based on Composer AI.