### PR TITLE
fix(Message): Truncate very long names

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/BotMessage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Message from '@patternfly/virtual-assistant/dist/dynamic/Message';
 import patternflyAvatar from './patternfly_avatar.jpg';
 
-export const AttachmentMenuExample: React.FunctionComponent = () => {
+export const BotMessageExample: React.FunctionComponent = () => {
   const markdown = `
 Here is some YAML code:
 
@@ -62,11 +62,12 @@ export default MessageLoading;
 
   return (
     <>
+      <Message name="Bot" role="bot" avatar={patternflyAvatar} content={`Text-based message from a bot named "Bot`} />
       <Message
         name="Bot"
         role="bot"
         avatar={patternflyAvatar}
-        content="Example content with updated timestamp text"
+        content={`Text-based message from a bot named "Bot," with updated timestamp`}
         timestamp="1 hour ago"
       />
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content={markdown} />
@@ -74,12 +75,12 @@ export default MessageLoading;
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content={unorderedList} />
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content={moreComplexList} />
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content="Example content" isLoading />
-      <Message role="bot" avatar={patternflyAvatar} content="Message with no name" />
+      <Message role="bot" avatar={patternflyAvatar} content="Text-based message from a nameless bot" />
       <Message
         name="Default Openshift Container Platform Assistant That Can Help With Any Query You Might Need Help With"
         role="bot"
         avatar={patternflyAvatar}
-        content="Message with very long name"
+        content="Text-based message, where the bot's name is truncated"
       />
     </>
   );

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/BotMessage.tsx
@@ -62,7 +62,7 @@ export default MessageLoading;
 
   return (
     <>
-      <Message name="Bot" role="bot" avatar={patternflyAvatar} content={`Text-based message from a bot named "Bot`} />
+      <Message name="Bot" role="bot" avatar={patternflyAvatar} content={`Text-based message from a bot named "Bot"`} />
       <Message
         name="Bot"
         role="bot"

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/BotMessage.tsx
@@ -74,6 +74,13 @@ export default MessageLoading;
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content={unorderedList} />
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content={moreComplexList} />
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content="Example content" isLoading />
+      <Message role="bot" avatar={patternflyAvatar} content="Message with no name" />
+      <Message
+        name="Default Openshift Container Platform Assistant That Can Help With Any Query You Might Need Help With"
+        role="bot"
+        avatar={patternflyAvatar}
+        content="Message with very long name"
+      />
     </>
   );
 };

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/Messages.md
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/Messages.md
@@ -50,7 +50,7 @@ Messages from the chatbot will be marked with an "AI" label to clearly communica
 
 <br />
 
-By default, a date and timestamp is displayed with each message. You can update `timestamp` with a different [date and time format](/ux-writing/numerics) as needed.
+By default, a date and timestamp is displayed with each message. We recommend using the `timestamp` prop in real chatbots, since it will allow you to set persistent dates and times on messages, even if the messages re-render. You can update `timestamp` with a different [date and time format](/ux-writing/numerics) as needed.
 
 ```js file="./BotMessage.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/UserMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/virtual-assistant/examples/Messages/UserMessage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Message from '@patternfly/virtual-assistant/dist/dynamic/Message';
 import userAvatar from './user_avatar.jpg';
 
-export const AttachmentMenuExample: React.FunctionComponent = () => {
+export const UserMessageExample: React.FunctionComponent = () => {
   const markdown = `A paragraph with *emphasis* and **strong importance**.
 
 > A block quote with ~strikethrough~ and a URL: https://reactjs.org.

--- a/packages/module/src/Message/Message.scss
+++ b/packages/module/src/Message/Message.scss
@@ -15,6 +15,12 @@
   gap: var(--pf-t--global--spacer--lg);
   padding-bottom: var(--pf-t--global--spacer--2xl);
 
+  // Name
+  // --------------------------------------------------------------------------
+  .pf-v6-c-truncate {
+    --pf-v6-c-truncate--MinWidth: 0ch;
+    --pf-v6-c-truncate__start--MinWidth: 0ch;
+  }
   // Avatar
   // --------------------------------------------------------------------------
   .pf-v6-c-avatar {
@@ -61,6 +67,9 @@
     }
 
     // Timestamp
+    .pf-v6-c-timestamp {
+      flex: 1 0 max-content;
+    }
     time {
       font-size: var(--pf-t--global--font--size--xs);
     }

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Avatar, Label, LabelGroup, LabelGroupProps, LabelProps, Timestamp } from '@patternfly/react-core';
+import { Avatar, Label, LabelGroup, LabelGroupProps, LabelProps, Timestamp, Truncate } from '@patternfly/react-core';
 import MessageLoading from './MessageLoading';
 import CodeBlockMessage from './CodeBlockMessage/CodeBlockMessage';
 import TextMessage from './TextMessage/TextMessage';
@@ -116,7 +116,11 @@ export const Message: React.FunctionComponent<MessageProps> = ({
       <Avatar src={avatar ?? DEFAULTS[role].avatar} alt="" />
       <div className="pf-chatbot__message-contents">
         <div className="pf-chatbot__message-meta">
-          <span className="pf-chatbot__message-name">{name}</span>
+          {name && (
+            <span className="pf-chatbot__message-name">
+              <Truncate content={name} />
+            </span>
+          )}
           {role === 'bot' && (
             <Label variant="outline" isCompact>
               {botWord}


### PR DESCRIPTION
Our API has name as optional - I'm letting it render as optional and then also adding truncation if it gets really long. We prioritize the timestamp at full width over the name right now - let me know if we want to prioritize the name over the timestamp instead.

<img width="749" alt="Screenshot 2024-11-05 at 3 11 10 PM" src="https://github.com/user-attachments/assets/7ffa6965-3ba8-4198-9cf6-11d3d32a6685">
<img width="417" alt="Screenshot 2024-11-05 at 3 10 50 PM" src="https://github.com/user-attachments/assets/f4a765c7-9fbd-4503-bb32-16e71ec14d1f">
<img width="478" alt="Screenshot 2024-11-05 at 3 10 58 PM" src="https://github.com/user-attachments/assets/718290a9-8136-4ecf-9914-94cb69a72946">
<img width="394" alt="Screenshot 2024-11-05 at 3 10 26 PM" src="https://github.com/user-attachments/assets/dfbefbf7-b771-46f5-8453-cd5625233c2d">
