### PR TITLE
fix(MessageBox): Add 100% width

### DIFF
--- a/packages/module/src/MessageBox/MessageBox.scss
+++ b/packages/module/src/MessageBox/MessageBox.scss
@@ -26,6 +26,7 @@
   .pf-chatbot--fullscreen {
     .pf-chatbot__messagebox {
       max-width: 60rem;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
Noticed in Composer that we need this - having only the max width means that the box jumps around a bit resizing until it hits the max. This should fix it up.