### PR TITLE
fix(MessageBar): Add onChange prop that works

### DIFF
--- a/packages/module/src/MessageBar/MessageBar.test.tsx
+++ b/packages/module/src/MessageBar/MessageBar.test.tsx
@@ -87,6 +87,15 @@ describe('Message bar', () => {
     await userEvent.type(input, '[Enter]');
     expect(spy).toHaveBeenCalledTimes(1);
   });
+  it('calls onChange callback appropriately', async () => {
+    const spy = jest.fn();
+    render(<MessageBar onSendMessage={jest.fn} onChange={spy} />);
+    const input = screen.getByRole('textbox', { name: /Send a message.../i });
+    await userEvent.type(input, 'A');
+    expect(input).toHaveValue('A');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(expect.any(Object), 'A');
+  });
 
   // Send button
   // --------------------------------------------------------------------------

--- a/packages/module/src/MessageBar/MessageBar.tsx
+++ b/packages/module/src/MessageBar/MessageBar.tsx
@@ -61,6 +61,8 @@ export interface MessageBarProps extends TextAreaProps {
       props?: ButtonProps;
     };
   };
+  /** A callback for when the text area value changes. */
+  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>, value: string) => void;
 }
 
 export const MessageBar: React.FunctionComponent<MessageBarProps> = ({
@@ -75,6 +77,7 @@ export const MessageBar: React.FunctionComponent<MessageBarProps> = ({
   handleStopButton,
   hasStopButton,
   buttonProps,
+  onChange,
   ...props
 }: MessageBarProps) => {
   // Text Input
@@ -86,6 +89,7 @@ export const MessageBar: React.FunctionComponent<MessageBarProps> = ({
   const attachButtonRef = React.useRef<HTMLButtonElement>(null);
 
   const handleChange = React.useCallback((event) => {
+    onChange && onChange(event, event.target.value);
     setMessage(event.target.value);
   }, []);
 
@@ -98,7 +102,7 @@ export const MessageBar: React.FunctionComponent<MessageBarProps> = ({
   }, [onSendMessage]);
 
   const handleKeyDown = React.useCallback(
-    (event) => {
+    (event: React.KeyboardEvent) => {
       if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault();
         if (!isSendButtonDisabled && !hasStopButton) {


### PR DESCRIPTION
We spread the PF textarea props onto this, but the third-party doesn't return the same API. This will let consumers use onChange.