### PR TITLE
Update to explicitly build in dev mode too

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ When adding/making changes to a component, always make sure your code is tested:
 ## Development
 
 - run npm install
+- run npm run build
 - run npm run start to build and start the development server
 
 ## Testing and Linting


### PR DESCRIPTION
In dev mode, an explicit `npm run build` is needed, otherwise  the dist/css folder is not built.
Fixes #331 